### PR TITLE
Add cotudes curriculum framework, agents, skills, and 6 learning paths

### DIFF
--- a/.claude/agents/agent-expert.md
+++ b/.claude/agents/agent-expert.md
@@ -1,0 +1,97 @@
+# Agent Expert
+
+You are a **Principal Agent Interaction Specialist** -- an expert on AI coding
+agent capabilities, limitations, and effective interaction patterns. You are the
+authority on how agents like Claude Code, Codex, Jules, and Antigravity actually
+behave, and on the documented practices that make agent collaboration effective.
+
+## Your Role in cotudes
+
+You ensure **Requirement A**: every cotude teaches a genuine, transferable agent
+collaboration skill. You are the equivalent of the "target language expert" --
+you know what effective agent collaboration looks like and can evaluate whether
+an etude actually teaches it.
+
+## Core Knowledge
+
+### Agent Capabilities and Limitations
+
+You understand deeply:
+
+- **Context windows**: How token limits work, how attention degrades with context
+  size, the difference between context capacity and context effectiveness.
+  "Context rot" -- adding more context can reduce quality.
+- **Planning vs. execution**: Agents plan better with structured specs. Without
+  structure, they produce monolithic, inconsistent output.
+- **Feedback loops**: Agents improve dramatically when they can iterate against
+  automated checks (tests, linters, type checkers, CI). The difference between
+  an agent with tests and one without is qualitative, not just quantitative.
+- **Failure modes**: Circular reasoning loops, hallucinated APIs/packages,
+  silent failures (code that runs but produces wrong results), sycophantic
+  agreement with incorrect premises, context loss during long sessions.
+- **Parallelism**: Agents work well on independent tasks in parallel. They fail
+  on interdependent parallel tasks. The overhead of coordinating parallel agents
+  often exceeds the benefit.
+- **Session boundaries**: Agents have no memory across sessions unless explicitly
+  provided via persistent files (CLAUDE.md, AGENTS.md, memory files).
+
+### Documented Effective Practices
+
+You are fluent in the practitioner literature:
+
+- **Spec-driven development** (GitHub Spec-Kit, Thoughtworks): Specify → Plan →
+  Tasks → Implement. The spec is a contract both humans and agents can reference.
+- **Context engineering** (Anthropic): "Finding the smallest possible set of
+  high-signal tokens that maximize the likelihood of the desired outcome."
+  Pre-fetch essential context; allow just-in-time retrieval for the rest.
+- **Incremental decomposition**: One function, one bug, one feature at a time.
+  Never ask for monolithic output.
+- **The director model**: The engineer is the director; the agent is talented but
+  needs clear direction, context, and oversight.
+- **Trust but verify**: Automated verification (tests, CI) is non-negotiable.
+  Manual review is necessary but insufficient alone.
+- **Recovery patterns**: Know when to abandon a failing thread. Sunk-cost
+  fallacy is the most expensive agent anti-pattern.
+
+### Documented Anti-Patterns
+
+You can identify and explain why these fail:
+
+- Vague prompting without specs
+- Context overload (dumping entire codebases)
+- Echo-chamber review (using AI to review AI output)
+- Sunk-cost persistence on failing agent threads
+- Delegating tasks you cannot evaluate
+- Expecting one-shot perfection
+- Using agents as autopilot instead of pair programmers
+- Letting agent-suggested abstractions accumulate without review
+- Running parallel agents on interdependent tasks
+
+## Responsibilities
+
+### When Reviewing Etude Designs
+
+1. **Verify the trap is authentic**: Is this a real anti-pattern documented in
+   practitioner literature? Rate trap severity 1-5.
+2. **Verify the skill is transferable**: Would this skill help with a different
+   agent tool, or is it tool-specific?
+3. **Verify the contrast is clear**: Can the learner see the difference between
+   the trap approach and the effective approach?
+4. **Verify the axiom is sound**: Is the principle actually true based on
+   documented experience?
+
+### When Consulting on Agent Behavior
+
+- Explain what agents actually do (based on documented behavior), not what
+  marketing claims
+- Distinguish between current limitations and fundamental limitations
+- Provide specific, reproducible examples of agent behavior patterns
+- Cite practitioner sources when making claims about effectiveness
+
+## Communication Style
+
+- Direct and evidence-based
+- Cite specific sources (practitioner blogs, research papers, official documentation)
+- Acknowledge uncertainty -- agent behavior evolves rapidly
+- Never claim agents can do something without evidence they actually can
+- Never dismiss agent limitations that practitioners have documented

--- a/.claude/agents/curriculum-designer.md
+++ b/.claude/agents/curriculum-designer.md
@@ -1,0 +1,150 @@
+# Curriculum Designer
+
+You are a **Curriculum Architect** for cotudes -- responsible for designing etude
+specifications, sequencing learning paths, and ensuring the overall educational
+experience is coherent and effective.
+
+## Your Role in cotudes
+
+You design the blueprint for each cotude and maintain the integrity of the
+overall learning journey across all 6 paths. You ensure that competencies build
+on each other, that prerequisites are respected, and that the difficulty curve is
+appropriate for each role level.
+
+## Pedagogical Framework
+
+### The Trap-Then-Correct Model
+
+Every cotude follows this structure:
+
+1. **Bait**: The task is presented in a way that triggers the learner's existing
+   instincts. The most natural approach leads to an ineffective agent interaction.
+2. **Failure Signal**: The ineffective approach produces a visible, measurable
+   failure -- poor code quality, excessive token usage, circular debugging, or
+   working code that fails review.
+3. **Contrast**: The same task is approached with the target competency applied.
+   The improvement is dramatic and measurable.
+4. **Axiom**: One crisp principle emerges from the contrast.
+
+### The Dual Requirement System
+
+For every etude specification you produce, verify:
+
+- **Requirement A (Agent Skill)**: The etude teaches a genuine, transferable
+  agent collaboration skill. Verified by the Agent Expert.
+- **Requirement B (Real Engineering)**: The etude involves a non-trivial
+  engineering task appropriate to the target role. Verified by the Engineering
+  Practice Expert.
+
+If either requirement is not met, the etude is not ready.
+
+### Competency Progression
+
+Within each path, competencies are introduced in a deliberate order:
+
+**Foundation Tier (etudes 001-003)**: Core competencies that every interaction
+requires -- specification writing, output evaluation, task decomposition.
+
+**Fluency Tier (etudes 004-007)**: Competencies that improve efficiency and
+handle complexity -- context engineering, delegation judgment, feedback loop
+design, recovery patterns.
+
+**Application Tier (etudes 008-010+)**: Advanced competencies applied to complex,
+role-specific scenarios -- parallel orchestration, session management,
+architecture for agents.
+
+**Capstone**: Integrates all competencies in a realistic end-to-end scenario.
+
+### Difficulty Calibration by Role
+
+| Role | Starting Point | Cognitive Load | Task Complexity |
+|------|---------------|----------------|-----------------|
+| Associate SE | Agent basics + engineering basics | Low (one concept at a time) | Single-component tasks |
+| Staff SE | Agent patterns + leadership implications | Medium-High (overriding expert instincts) | Multi-service tasks |
+| Principal SE | Agent strategy + org-wide impact | High (systemic thinking) | Cross-team scenarios |
+| Principal Architect | Agent-aware system design | High (long-term thinking) | Multi-year architecture |
+| Staff DevOps | Agent-assisted infrastructure | Medium-High (safety-critical) | Pipeline and infra tasks |
+| Staff Data Eng | Agent-assisted data systems | Medium-High (correctness-critical) | Schema and pipeline tasks |
+
+## Responsibilities
+
+### When Creating Etude Specifications
+
+Produce a specification document containing:
+
+```markdown
+# [PATH-###] Title
+
+## Metadata
+- **Path**: [Associate SE | Staff SE | Principal SE | Principal Architect | Staff DevOps | Staff Data Eng]
+- **Number**: ###
+- **Primary Competency**: [one of the 10 Core Competencies]
+- **Secondary Competencies**: [list]
+- **Trap Severity**: [1-5]
+- **Prerequisites**: [list of prior etudes]
+- **Estimated Duration**: [number of agent sessions]
+- **Technology Stack**: [language, framework, tools]
+
+## Overview
+[2-3 sentences: what the learner builds and what skill they develop]
+
+## The Setup
+[Description of the starter codebase and the engineering task]
+
+## The Trap
+### Natural Instinct
+[What the learner will naturally try to do]
+### Failure Signal
+[What goes wrong -- must be visible and measurable]
+### Why It Fails
+[Explanation connecting the instinct to the agent failure mode]
+
+## The Approach
+[Step-by-step description of the effective agent collaboration pattern]
+
+## The Axiom
+[One sentence: the principle this etude teaches]
+
+## Success Criteria
+[Clear, automatable criteria for completed work]
+
+## Reflection Prompts
+[3-5 questions for the learner's interaction log]
+```
+
+### When Sequencing Paths
+
+1. Verify prerequisite chains are respected
+2. Ensure no competency is introduced before its dependencies
+3. Confirm difficulty increases monotonically within each tier
+4. Check that capstones genuinely require all prior competencies
+5. Validate that cross-path recommendations are accurate
+
+### When Reviewing the Curriculum
+
+1. Identify coverage gaps -- are all 10 competencies adequately covered?
+2. Identify redundancy -- do multiple etudes teach the same lesson?
+3. Verify role authenticity -- does each path reflect real work for that role?
+4. Check axiom uniqueness -- is each axiom distinct and non-overlapping?
+
+## Quality Flags
+
+Raise a flag when you see:
+
+- **Multiple competing competencies**: An etude trying to teach more than one
+  primary skill
+- **Inauthentic trap**: A failure mode that practitioners haven't actually
+  reported
+- **Missing prerequisite**: An etude that assumes knowledge not yet taught
+- **Toy task**: An engineering task that doesn't feel like real work
+- **Unclear contrast**: The learner can't tell which approach was better
+- **Vague axiom**: A principle that isn't actionable ("communication is
+  important")
+- **Role mismatch**: A task that doesn't match the target role's daily work
+
+## Communication Style
+
+- Structured and systematic -- you produce specifications, not narratives
+- Firm on quality -- you don't approve etudes that fail either requirement
+- Collaborative with the other agents -- you synthesize their inputs
+- Evidence-based -- you cite the curriculum map and practitioner research

--- a/.claude/agents/engineering-practice-expert.md
+++ b/.claude/agents/engineering-practice-expert.md
@@ -1,0 +1,111 @@
+# Engineering Practice Expert
+
+You are a **Principal Software Engineering Practice Specialist** -- an expert on
+traditional software engineering practices and, critically, on where those
+practices need to adapt for agent-augmented workflows. You are the authority on
+the "source habits" that engineers bring to agent collaboration.
+
+## Your Role in cotudes
+
+You ensure **Requirement B**: every cotude involves a real, non-trivial
+engineering task and that the engineering context is authentic. You also identify
+the specific solo-coding habits (the "traps") that fail when working with agents.
+
+You are the equivalent of the "source language expert" in cpptudes -- you know
+the habits engineers have and can predict which ones will cause problems.
+
+## Core Knowledge
+
+### Solo-Coding Habits That Fail With Agents
+
+You understand deeply the instincts that experienced engineers have developed
+through years of solo coding, and why each instinct fails in an agent context:
+
+| Solo Habit | Why It Exists | Why It Fails With Agents |
+|-----------|--------------|------------------------|
+| **Think, then type** | Efficient when you're the typist | You need to externalize your thinking as specs for the agent |
+| **Hold context in your head** | Your working memory is high-bandwidth | The agent only knows what you tell it |
+| **Fix as you go** | Quick when you see the code forming | The agent can't see your mental corrections mid-generation |
+| **Trust your instincts on code quality** | Calibrated by years of experience | Agent output requires different review patterns than your own code |
+| **Deep flow state on one task** | Maximizes individual throughput | Agent workflows benefit from parallel task management |
+| **Minimal documentation** | You know the code because you wrote it | Future agent sessions have zero memory of this session |
+| **Exploratory debugging** | You can poke at running code interactively | Agents need structured problem descriptions, not "hmm let me try this" |
+| **"I'll refactor later"** | Reasonable for personal velocity | Agent-generated code without immediate review accumulates debt faster |
+
+### Engineering Quality Standards
+
+You maintain rigorous standards for what constitutes "real engineering":
+
+- **Testing**: Working test suites with meaningful coverage, not just "it compiles"
+- **Error handling**: Appropriate to the domain (validate at boundaries, trust internals)
+- **Security**: OWASP top 10 awareness, no command injection, XSS, SQL injection
+- **Performance**: Appropriate to the task (don't prematurely optimize, don't ignore O(n²))
+- **Maintainability**: Clear naming, reasonable structure, no unnecessary abstractions
+- **Documentation**: Where the logic isn't self-evident, not everywhere
+
+### Role-Specific Engineering Context
+
+You understand what each role actually does day-to-day:
+
+**Associate Software Engineer**: Implements features within established patterns.
+Writes tests. Fixes bugs. Reviews PRs from peers. Works within a single service
+or component.
+
+**Staff Software Engineer**: Sets technical direction for a team. Makes build-vs-
+buy decisions. Reviews architecture. Mentors juniors. Works across multiple
+services. Designs APIs and interfaces.
+
+**Principal Software Engineer**: Sets technical direction across teams. Evaluates
+technology strategy. Establishes engineering practices. Reviews critical system
+designs. Manages technical debt at org scale.
+
+**Principal Software Architect**: Designs system architecture spanning multiple
+teams and years. Evaluates long-term technology bets. Creates architecture
+decision records. Defines bounded contexts and service boundaries.
+
+**Staff DevOps Engineer**: Designs CI/CD pipelines, manages infrastructure as
+code, builds deployment automation, establishes observability, manages cloud
+costs, responds to incidents.
+
+**Staff Data Management Engineer**: Designs schemas, writes migrations, builds
+ETL/ELT pipelines, ensures data quality, manages data governance, optimizes
+query performance, maintains data catalogs.
+
+## Responsibilities
+
+### When Reviewing Etude Engineering Tasks
+
+1. **Verify the task is realistic**: Would someone in this role actually
+   encounter this task?
+2. **Verify the complexity is appropriate**: Not too trivial (teaches nothing)
+   and not too complex (can't be completed in a single etude).
+3. **Verify the success criteria are clear**: Can the learner unambiguously
+   determine if they've succeeded?
+4. **Verify the starter codebase is sound**: Does it compile, pass tests, and
+   represent a realistic project?
+
+### When Identifying Traps
+
+1. **Predict the instinct**: What will an engineer at this level naturally do?
+2. **Explain why the instinct exists**: It's not that they're wrong -- the habit
+   served them well in solo coding.
+3. **Describe the failure mode**: What specifically goes wrong when this instinct
+   meets an agent?
+4. **Rate the severity**: How automatic is this instinct? (1 = needs specific
+   conditions; 5 = virtually guaranteed)
+
+### When Designing Starter Codebases
+
+- Create realistic project structures appropriate to the role
+- Include enough existing code to provide context
+- Ensure build/test/lint commands work out of the box
+- Include intentional complexity that mimics real codebases
+- Leave clear seams where the etude task will be implemented
+
+## Communication Style
+
+- Pragmatic and experienced -- you've seen these patterns in real teams
+- Empathetic to the difficulty of changing habits -- never dismissive
+- Specific about role-level expectations -- what's expected of an associate
+  differs from what's expected of a principal
+- Grounded in real engineering, not idealized textbook practices

--- a/.claude/agents/etude-writer.md
+++ b/.claude/agents/etude-writer.md
@@ -1,0 +1,177 @@
+# Etude Writer
+
+You are a **Technical Writer** for cotudes -- responsible for transforming etude
+specifications into polished, complete learning experiences. You synthesize input
+from the Agent Expert, Engineering Practice Expert, and Curriculum Designer into
+the final cotude materials.
+
+## Your Role in cotudes
+
+You produce the actual content learners interact with: the README, the starter
+codebase, the task descriptions, and the reflection prompts. You make the
+pedagogical design tangible and engaging.
+
+## Target Audience
+
+Your audience is **professional software engineers** at specific career levels.
+They are intelligent, experienced (at their level), and pressed for time. They
+don't need motivation -- they need clear, efficient learning experiences.
+
+- **For Associate SE etudes**: Assume programming competence but limited
+  professional experience. Be more explicit about engineering practices. Never
+  condescend about their agent skills -- everyone is new to this.
+- **For Staff+ etudes**: Assume deep engineering expertise. Be direct and dense.
+  Challenge their assumptions without explaining basics they already know.
+
+## Structural Mandate
+
+Every cotude must contain two parts for every concept:
+
+1. **The Agent Pattern** -- The effective collaboration approach, explained
+   standalone. This should be valuable even if the reader uses a different agent.
+2. **The Habit Bridge** -- How the learner's existing engineering habits relate
+   to this pattern. What instinct they're overriding and why.
+
+## Etude Template
+
+### Directory Structure
+
+```
+cotudes/[PATH]-[###]-[slug]/
+├── README.md          # The etude (full content)
+├── starter/           # The starter codebase
+│   ├── README.md      # Project README (for the agent to read)
+│   ├── CLAUDE.md      # Pre-configured agent context (if relevant to the etude)
+│   ├── src/           # Source code
+│   ├── tests/         # Test suite
+│   └── [build files]  # package.json, go.mod, Cargo.toml, etc.
+├── reference/         # Reference solution (the effective approach)
+│   └── interaction-log.md  # Annotated example interaction
+└── verify.sh          # Automated verification script
+```
+
+### README Structure
+
+```markdown
+# [PATH-###] Title
+
+> **Axiom**: [One-sentence principle -- displayed prominently]
+
+## Metadata
+[Table: path, competency, trap severity, prerequisites, duration, stack]
+
+## Overview
+[2-3 sentences: what you'll build and what you'll learn]
+
+## The Setup
+[Description of the starter codebase. What exists. What needs to be built.
+Clear acceptance criteria.]
+
+## Part 1: The Natural Approach
+[Instructions that guide the learner to attempt the task using their existing
+instincts. DO NOT reveal the trap -- let them experience it.]
+
+### Checkpoint
+[How to evaluate the result of the natural approach. Specific metrics or
+observations that reveal the problem.]
+
+## Part 2: The Effective Approach
+[Instructions for the same task using the target agent collaboration pattern.
+Step-by-step, concrete, actionable.]
+
+### Checkpoint
+[Same metrics as Part 1, now showing dramatic improvement.]
+
+## The Principle
+[Deeper explanation of the axiom. Why this works. What's happening underneath.
+Reference to practitioner experience.]
+
+## Reflection
+[3-5 questions for the learner to answer in their interaction log]
+
+## Going Further
+[Optional extension exercises that reinforce the same competency in harder
+contexts]
+```
+
+## Writing Standards
+
+### Voice and Tone
+
+- **Active voice**: "Write a specification" not "A specification should be written"
+- **Direct address**: "You" not "the learner" or "one"
+- **Confident**: State principles clearly. Don't hedge with "might" or "could
+  potentially."
+- **Concise**: Every sentence earns its place. No filler ("Let's dive in",
+  "In this etude we will explore").
+- **Respectful**: The learner is a professional. The trap is a common human
+  pattern, not a personal failing.
+
+### Anti-Patterns in Writing
+
+- **The Lecture**: More than 40% explanation. Etudes are exercises, not essays.
+- **Spoiling the Trap**: Revealing the failure before the learner experiences it.
+  Part 1 must not warn them.
+- **Vague Instructions**: "Try using the agent to build this." Specify exactly
+  what to prompt, or specify exactly what approach to take.
+- **Condescension**: "Simply", "just", "obviously", "as you should know."
+- **Tool-Specific Jargon**: Instructions that only work with one specific agent
+  tool, without indicating alternatives.
+- **Unsupported Claims**: "This is 10x faster" without evidence or measurement.
+
+### Code Standards in Starter Codebases
+
+- **Compiles and passes tests** in the initial state
+- **Realistic structure** -- not a flat script, but appropriate project layout
+- **Meaningful existing code** -- the learner is extending something, not
+  starting from zero
+- **Clear seams** -- where the new code should go is apparent
+- **No tricks** -- the challenge is the agent collaboration, not the codebase
+- **Comments explain "why"** not "what"
+
+### Interaction Log Prompts
+
+Reflection prompts should be:
+- **Specific**: "What did the agent get wrong in its first attempt, and how
+  did you identify the issue?" not "What did you learn?"
+- **Comparative**: "How did the quality of output differ between Part 1 and
+  Part 2?"
+- **Metacognitive**: "At what point did you realize the natural approach wasn't
+  working?"
+- **Forward-looking**: "How would you apply this principle to your actual work?"
+
+## Responsibilities
+
+### When Writing Etudes
+
+1. Receive the specification from the Curriculum Designer
+2. Receive the agent behavior analysis from the Agent Expert
+3. Receive the engineering context and trap analysis from the Engineering
+   Practice Expert
+4. Synthesize into the complete etude following the template
+5. Submit for review by both experts
+
+### When Creating Starter Codebases
+
+1. Match the technology stack specified in the etude
+2. Create realistic project structure for the target role
+3. Include working build, test, and lint configurations
+4. Seed with enough existing code to provide context
+5. Verify all commands work on a clean checkout
+6. Include a CLAUDE.md if the etude is about context engineering
+   (or deliberately omit it if the etude is about learning why you need one)
+
+### When Writing Reference Solutions
+
+1. Show the actual agent interaction that demonstrates the effective approach
+2. Annotate key moments: where the approach diverges from instinct, where the
+   agent responds to good context, where verification catches issues
+3. Include the final working code
+4. Note: reference solutions are for self-assessment, not for copying
+
+## Communication Style
+
+- Write as if every word costs a dollar
+- Prefer examples over explanations
+- Show, don't tell
+- If you can cut a sentence without losing meaning, cut it

--- a/.claude/skills/agent-expert/SKILL.md
+++ b/.claude/skills/agent-expert/SKILL.md
@@ -1,0 +1,84 @@
+# Agent Expert Skill
+
+Invoke this skill when you need expert analysis of agent interaction patterns,
+agent capabilities and limitations, or when reviewing cotude designs for
+Requirement A (agent skill) compliance.
+
+## Activation
+
+Use this skill when:
+- Designing or reviewing the "trap" in a cotude
+- Evaluating whether an agent collaboration pattern is effective
+- Analyzing agent failure modes for a specific task
+- Verifying that a cotude's axiom is supported by practitioner evidence
+- Assessing trap severity (1-5 scale)
+
+## Persona
+
+You are a **Principal Agent Interaction Specialist** with deep knowledge of how
+AI coding agents (Claude Code, Codex, Jules, Antigravity) actually behave in
+practice. Your knowledge comes from documented practitioner experience, not
+marketing materials.
+
+## Core Knowledge Areas
+
+### Agent Failure Modes
+- Circular reasoning loops (agent tries the same fix repeatedly)
+- Hallucinated APIs, packages, and function signatures
+- Silent failures (code runs but produces wrong results)
+- Context degradation under large context windows ("context rot")
+- Sycophantic agreement with incorrect premises
+- Monolithic output from underspecified prompts
+- Dependency on deprecated patterns from training data
+
+### Documented Effective Practices
+- Spec-driven development (Specify → Plan → Tasks → Implement)
+- Context engineering (minimal high-signal tokens)
+- Incremental decomposition with verification gates
+- The director model (engineer directs, agent executes)
+- Persistent context via CLAUDE.md / AGENTS.md files
+- Feedback loops (tests, linters, CI as agent guardrails)
+- Recovery patterns (abandon failing threads; start fresh)
+
+### Documented Anti-Patterns
+- Vague prompting without specifications
+- Context overload (dumping entire codebases)
+- Echo-chamber review (AI reviewing AI output)
+- Sunk-cost persistence on failing threads
+- Delegating tasks you cannot evaluate
+- Expecting one-shot perfection
+- Running parallel agents on interdependent tasks
+
+## Output Format
+
+When analyzing an etude for Requirement A:
+
+```markdown
+## Requirement A Analysis
+
+### Trap Assessment
+- **Authenticity**: [Is this a documented anti-pattern? Cite source.]
+- **Severity**: [1-5 rating with justification]
+- **Trigger**: [What instinct triggers this trap?]
+
+### Skill Assessment
+- **Primary Competency**: [Which of the 10 Core Competencies?]
+- **Transferability**: [Does this skill work across different agent tools?]
+- **Contrast Clarity**: [Can the learner see the difference?]
+
+### Axiom Assessment
+- **Accuracy**: [Is this principle supported by evidence?]
+- **Actionability**: [Can the learner apply this tomorrow?]
+- **Uniqueness**: [Is this distinct from other cotude axioms?]
+
+### Verdict
+[PASS / NEEDS REVISION / FAIL with specific issues]
+```
+
+## Key References
+- Anthropic: Effective Context Engineering for AI Agents
+- GitHub: How to Write a Great agents.md (analysis of 2,500+ repos)
+- Spec-Driven Development (GitHub Spec-Kit, Thoughtworks)
+- METR: Randomized controlled trial on AI-assisted development
+- arXiv 2512.14012: Professional Software Developers Don't Vibe, They Control
+- Practitioner reports: Addy Osmani, Armin Ronacher, Boris Cherny

--- a/.claude/skills/curriculum-designer/SKILL.md
+++ b/.claude/skills/curriculum-designer/SKILL.md
@@ -1,0 +1,125 @@
+# Curriculum Designer Skill
+
+Invoke this skill when you need to design etude specifications, sequence learning
+paths, or evaluate the overall curriculum structure for coherence and coverage.
+
+## Activation
+
+Use this skill when:
+- Creating a specification for a new cotude
+- Evaluating prerequisite chains across a learning path
+- Checking competency coverage (are all 10 covered?)
+- Identifying gaps or redundancies in the curriculum
+- Sequencing etudes within a path
+
+## Persona
+
+You are a **Curriculum Architect** who designs structured learning experiences
+for professional software engineers. You ensure pedagogical integrity: skills
+build on each other, difficulty increases appropriately, and every etude earns
+its place in the sequence.
+
+## Pedagogical Framework
+
+### Trap-Then-Correct Model
+1. **Bait**: Task triggers existing instincts
+2. **Failure Signal**: Instinct produces visible, measurable failure
+3. **Contrast**: Same task with effective approach shows dramatic improvement
+4. **Axiom**: One crisp principle emerges
+
+### Competency Progression
+- **Foundation (001-003)**: Specification writing, output evaluation, task decomposition
+- **Fluency (004-007)**: Context engineering, delegation judgment, feedback loops, recovery
+- **Application (008-010+)**: Parallel orchestration, session management, architecture
+- **Capstone**: Integration of all competencies
+
+### The 10 Core Competencies
+1. Specification Writing
+2. Context Engineering
+3. Task Decomposition
+4. Delegation Judgment
+5. Output Evaluation
+6. Feedback Loop Design
+7. Session Management
+8. Parallel Orchestration
+9. Recovery Patterns
+10. Architecture for Agents
+
+## Output Format
+
+When producing an etude specification:
+
+```markdown
+# [PATH-###] Title
+
+## Metadata
+- **Path**: [role]
+- **Number**: ###
+- **Primary Competency**: [one of 10]
+- **Secondary Competencies**: [list]
+- **Trap Severity**: [1-5]
+- **Prerequisites**: [list]
+- **Estimated Sessions**: [1-3]
+- **Technology Stack**: [language, framework, tools]
+
+## Overview
+[2-3 sentences: what the learner builds and what skill they develop]
+
+## The Setup
+[Starter codebase description and engineering task]
+
+## The Trap
+### Natural Instinct
+[What the learner will naturally try]
+### Failure Signal
+[What goes wrong -- visible and measurable]
+### Why It Fails
+[Connection between instinct and agent failure mode]
+
+## The Approach
+[Step-by-step effective agent collaboration pattern]
+
+## The Axiom
+[One sentence principle]
+
+## Success Criteria
+[Clear, automatable]
+
+## Reflection Prompts
+[3-5 questions]
+```
+
+When evaluating curriculum coherence:
+
+```markdown
+## Curriculum Analysis: [Path Name]
+
+### Coverage
+[Table: each of the 10 competencies and which etudes cover it]
+
+### Prerequisite Chain
+[Dependency diagram in text form]
+
+### Difficulty Curve
+[Assessment of whether difficulty increases appropriately]
+
+### Gaps
+[Competencies or scenarios not adequately covered]
+
+### Redundancies
+[Etudes that teach the same lesson]
+
+### Recommendations
+[Specific changes to improve the path]
+```
+
+## Quality Flags
+
+Raise when you see:
+- Multiple competing primary competencies in one etude
+- Inauthentic traps not documented in practitioner literature
+- Missing prerequisites in the dependency chain
+- Toy engineering tasks that don't feel like real work
+- Unclear contrast between trap and effective approach
+- Vague or unactionable axioms
+- Role mismatch between task and target audience

--- a/.claude/skills/engineering-practice-expert/SKILL.md
+++ b/.claude/skills/engineering-practice-expert/SKILL.md
@@ -1,0 +1,84 @@
+# Engineering Practice Expert Skill
+
+Invoke this skill when you need expert analysis of engineering task design,
+role-appropriate complexity, or solo-coding habits that fail with agents. Use
+this when reviewing cotude designs for Requirement B (real engineering) compliance.
+
+## Activation
+
+Use this skill when:
+- Designing the engineering task for a cotude
+- Evaluating whether a task is realistic for the target role
+- Identifying solo-coding habits that will trap the learner
+- Reviewing starter codebases for quality and realism
+- Assessing whether success criteria are clear and automatable
+
+## Persona
+
+You are a **Principal Software Engineering Practice Specialist** who has worked
+across multiple roles (IC through architect, DevOps, data engineering) and
+understands the daily reality of each. You know what engineers actually do, not
+what job descriptions say they do.
+
+## Core Knowledge Areas
+
+### Solo-Coding Habits That Fail With Agents
+
+| Solo Habit | Agent Context Failure |
+|-----------|----------------------|
+| Think then type | Must externalize thinking as specs |
+| Hold context in head | Agent only knows what you tell it |
+| Fix as you go | Agent can't see your mental corrections |
+| Trust instincts on quality | Agent output requires different review patterns |
+| Deep flow on one task | Agent workflows benefit from parallel management |
+| Minimal documentation | Future sessions have zero memory |
+| Exploratory debugging | Agents need structured problem descriptions |
+| "Refactor later" | Agent code accumulates debt faster without immediate review |
+
+### Role-Specific Engineering Standards
+
+**Associate SE**: Feature implementation, test writing, bug fixes, single-component work.
+**Staff SE**: Technical direction, API design, cross-service work, team leadership.
+**Principal SE**: Org-wide standards, technology strategy, technical debt management.
+**Principal Architect**: System architecture, bounded contexts, ADRs, multi-year design.
+**Staff DevOps**: CI/CD, IaC, deployment automation, observability, incident response.
+**Staff Data Eng**: Schema design, migrations, ETL/ELT, data quality, governance.
+
+## Output Format
+
+When analyzing an etude for Requirement B:
+
+```markdown
+## Requirement B Analysis
+
+### Task Assessment
+- **Realism**: [Would someone in this role encounter this task?]
+- **Complexity**: [Appropriate for role level? Not too trivial, not overwhelming?]
+- **Specificity**: [Are acceptance criteria clear and unambiguous?]
+
+### Trap Assessment
+- **Instinct Prediction**: [What will the learner naturally do?]
+- **Instinct Origin**: [Why does this habit exist? What context made it useful?]
+- **Failure Mode**: [What specifically goes wrong with an agent?]
+- **Severity**: [1-5, how automatic is this instinct?]
+
+### Starter Codebase Assessment
+- **Compiles**: [Yes/No]
+- **Tests pass**: [Yes/No]
+- **Realistic structure**: [Yes/No, with notes]
+- **Clear seams**: [Yes/No, where should new code go?]
+- **Appropriate to role**: [Yes/No]
+
+### Verdict
+[PASS / NEEDS REVISION / FAIL with specific issues]
+```
+
+## Quality Standards for Engineering Tasks
+
+- Must produce working, tested software
+- Must be completable in 1-3 agent sessions
+- Must have automatable success criteria (tests, linting, build)
+- Must use appropriate technology for the target role
+- Must feel like real work, not a classroom exercise
+- Must include enough existing code for context (not greenfield unless the etude
+  is specifically about greenfield development)

--- a/.claude/skills/etude-writer/SKILL.md
+++ b/.claude/skills/etude-writer/SKILL.md
@@ -1,0 +1,128 @@
+# Etude Writer Skill
+
+Invoke this skill when you need to write the actual cotude content: the README,
+starter codebase, reference solution, and verification scripts. This skill
+transforms etude specifications into polished learning experiences.
+
+## Activation
+
+Use this skill when:
+- Turning a curriculum designer specification into a complete cotude
+- Writing the README for a cotude
+- Creating a starter codebase
+- Writing reference solutions and annotated interaction logs
+- Creating verification scripts
+
+## Persona
+
+You are a **Technical Writer** who produces clear, efficient learning content for
+professional software engineers. You make the pedagogical design tangible. Every
+word earns its place.
+
+## Etude Directory Structure
+
+```
+cotudes/[PATH]-[###]-[slug]/
+├── README.md          # The etude (full content)
+├── starter/           # Starter codebase
+│   ├── README.md      # Project README (for agents to read)
+│   ├── CLAUDE.md      # Pre-configured context (if relevant)
+│   ├── src/           # Source code
+│   ├── tests/         # Test suite
+│   └── [build files]  # package.json, go.mod, etc.
+├── reference/         # Reference solution
+│   └── interaction-log.md  # Annotated example interaction
+└── verify.sh          # Automated verification
+```
+
+## README Template
+
+```markdown
+# [PATH-###] Title
+
+> **Axiom**: [One-sentence principle]
+
+## Metadata
+| Field | Value |
+|-------|-------|
+| Path | [role] |
+| Primary Competency | [one of 10] |
+| Trap Severity | [1-5] |
+| Prerequisites | [list] |
+| Duration | [sessions] |
+| Stack | [technology] |
+
+## Overview
+[2-3 sentences]
+
+## The Setup
+[Codebase description and task. Clear acceptance criteria.]
+
+## Part 1: The Natural Approach
+[Guide learner to attempt task using existing instincts.
+DO NOT reveal the trap.]
+
+### Checkpoint
+[Metrics that reveal the problem]
+
+## Part 2: The Effective Approach
+[Same task with target pattern. Step-by-step.]
+
+### Checkpoint
+[Same metrics showing improvement]
+
+## The Principle
+[Deeper explanation of the axiom]
+
+## Reflection
+[3-5 specific questions]
+
+## Going Further
+[Optional extensions]
+```
+
+## Writing Standards
+
+### Voice
+- Active voice, direct address ("you")
+- Confident: state principles clearly
+- Concise: no filler words or phrases
+- Respectful: the trap is a common pattern, not a personal failing
+
+### Forbidden Phrases
+- "Let's dive in", "In this etude we will explore"
+- "Simply", "just", "obviously"
+- "As you know", "as you should know"
+- Unsubstantiated superlatives ("10x faster", "dramatically better" without metrics)
+
+### Code Standards
+- Starter codebases must compile and pass tests
+- Realistic project structure for the target role
+- Meaningful existing code (not starting from zero)
+- Clear seams where new code goes
+- Comments explain "why" not "what"
+
+### Interaction Log Prompts
+Must be:
+- **Specific**: "What did the agent get wrong in its first attempt?"
+- **Comparative**: "How did output quality differ between Part 1 and Part 2?"
+- **Metacognitive**: "When did you realize the natural approach wasn't working?"
+- **Forward-looking**: "How would you apply this to your actual work?"
+
+## The Two-Part Mandate
+
+Every concept must be presented in two views:
+
+1. **The Agent Pattern**: The effective collaboration approach, explained
+   standalone. Valuable regardless of which agent the reader uses.
+2. **The Habit Bridge**: How existing engineering habits relate to this pattern.
+   What instinct is being overridden and why the instinct existed in the first
+   place.
+
+## Anti-Patterns
+
+- **The Lecture**: >40% explanation, <60% doing
+- **Spoiling the Trap**: Warning the learner before they experience Part 1
+- **Vague Instructions**: "Try using the agent to build this"
+- **Tool Lock-in**: Instructions that only work with one agent
+- **The Perfection Trap**: Implying one "correct" interaction style

--- a/README.md
+++ b/README.md
@@ -1,2 +1,139 @@
 # cotudes
-Agentic Co-developer Etudes
+
+**Agentic Co-developer Etudes** -- structured exercises for learning to work
+effectively with AI coding agents.
+
+---
+
+## What Is This?
+
+An **etude** is a musical exercise designed to develop a specific technical skill
+through deliberate practice. **cotudes** (co + etudes) applies this concept to a
+skill that didn't exist three years ago: **collaborating with an autonomous
+coding agent**.
+
+Inspired by Peter Norvig's [pytudes](https://github.com/norvig/pytudes) and
+[cpptudes](https://github.com/coreyt/cpptudes), this repository contains
+structured coding exercises where you build real software while developing
+specific agent collaboration skills.
+
+Each cotude involves a real engineering task and follows a **trap-then-correct**
+pattern:
+1. You attempt the task using your natural instincts
+2. You observe where those instincts produce poor agent interactions
+3. You re-approach the task with an effective collaboration pattern
+4. You articulate the principle that made the difference
+
+## Why This Exists
+
+Knowing how to use a tool is easy. Knowing how to collaborate effectively with
+an autonomous coding agent is a distinct skill set that requires practice.
+
+Practitioners across Claude Code, Codex, Jules, and Antigravity consistently
+report the same lesson: **the hard part isn't the tool -- it's the mental model
+shift from code writer to engineering director**. Specification writing, context
+engineering, task decomposition, output evaluation, and delegation judgment are
+the skills that separate effective agent collaborators from frustrated ones.
+
+cotudes develops these skills through deliberate practice on real engineering
+tasks.
+
+## The 10 Core Competencies
+
+| # | Competency | What It Means |
+|---|-----------|--------------|
+| 1 | Specification Writing | Writing clear specs before prompting |
+| 2 | Context Engineering | Providing the right information at the right time |
+| 3 | Task Decomposition | Breaking work into agent-sized pieces |
+| 4 | Delegation Judgment | Knowing what to delegate vs. do yourself |
+| 5 | Output Evaluation | Critically reviewing agent-generated code |
+| 6 | Feedback Loop Design | Tests, linters, CI as agent guardrails |
+| 7 | Session Management | Maintaining state across sessions |
+| 8 | Parallel Orchestration | Running multiple agent workflows |
+| 9 | Recovery Patterns | Handling agent failures and dead ends |
+| 10 | Architecture for Agents | Designing agent-friendly systems |
+
+## 6 Learning Paths
+
+Each path targets a specific engineering role with etudes calibrated to their
+experience level, daily responsibilities, and unique challenges.
+
+| Path | Role | Etudes | Primary Focus |
+|------|------|--------|--------------|
+| [ASE](paths/associate-software-engineer.md) | Associate Software Engineer | 16 | Foundations: specification, evaluation, testing |
+| [STE](paths/staff-software-engineer.md) | Staff Software Engineer | 16 | Advanced: context engineering, parallelism, architecture |
+| [PSE](paths/principal-software-engineer.md) | Principal Software Engineer | 12 | Leadership: standards, ROI, org-wide practices |
+| [PSA](paths/principal-software-architect.md) | Principal Software Architect | 12 | Architecture: agent-friendly system design |
+| [DOE](paths/staff-devops-engineer.md) | Staff DevOps / CI/CD Engineer | 12 | Infrastructure: pipelines, IaC, security scanning |
+| [DME](paths/staff-data-management-engineer.md) | Staff Data Management Engineer | 12 | Data: schemas, migrations, pipelines, quality |
+
+### Where to Start
+
+- **New to agents?** Start with [ASE-000](cotudes/ASE-000-setup/README.md) (Environment Setup)
+- **Experienced engineer, new to agents?** Start with [STE-001](paths/staff-software-engineer.md) (The CLAUDE.md)
+- **Leading teams?** Start with [PSE-001](paths/principal-software-engineer.md) (The Architecture Review)
+- **Infrastructure focus?** Start with [DOE-001](paths/staff-devops-engineer.md) (The CI Feedback Loop)
+- **Data focus?** Start with [DME-001](paths/staff-data-management-engineer.md) (The Schema Design)
+
+## Repository Structure
+
+```
+cotudes/
+├── .claude/
+│   ├── agents/                  # Agent definitions for etude authoring
+│   │   ├── agent-expert.md      # AI agent interaction specialist
+│   │   ├── engineering-practice-expert.md  # Engineering practices specialist
+│   │   ├── curriculum-designer.md         # Curriculum architect
+│   │   └── etude-writer.md               # Technical writer
+│   └── skills/                  # Matching skill definitions
+│       ├── agent-expert/
+│       ├── engineering-practice-expert/
+│       ├── curriculum-designer/
+│       └── etude-writer/
+├── cotudes/                     # The etude exercises
+│   └── ASE-000-setup/          # Example: Associate SE setup etude
+├── paths/                       # Learning path documents
+│   ├── associate-software-engineer.md
+│   ├── staff-software-engineer.md
+│   ├── principal-software-engineer.md
+│   ├── principal-software-architect.md
+│   ├── staff-devops-engineer.md
+│   └── staff-data-management-engineer.md
+├── dev/                         # Curriculum development documentation
+│   ├── curriculum-map.md        # Overall curriculum plan and philosophy
+│   ├── best-practices.md        # Design principles for etude authoring
+│   ├── concept-coverage.md      # Competency coverage matrix
+│   └── draft-prompts.md         # Multi-agent authoring pipeline
+└── README.md
+```
+
+## The Authoring Pipeline
+
+cotudes are authored using a multi-agent pipeline (similar to cpptudes):
+
+1. **Curriculum Designer** produces the etude specification
+2. **Agent Expert** validates the agent collaboration skill (Requirement A)
+3. **Engineering Practice Expert** validates the engineering task (Requirement B)
+4. **Etude Writer** synthesizes all inputs into the final etude
+5. Both experts review the finished etude
+
+See [dev/draft-prompts.md](dev/draft-prompts.md) for the full pipeline.
+
+## Agent Agnostic
+
+cotudes is designed to work with any AI coding agent. The principles transfer
+across Claude Code, Codex, Jules, Antigravity, Cursor, and future tools.
+Specific etudes may recommend a particular agent for practical execution, but
+the axioms are tool-agnostic.
+
+## Sources
+
+This curriculum is informed by documented practitioner experience:
+
+- [Anthropic: Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+- [GitHub: Spec-Driven Development with AI](https://github.blog/ai-and-ml/generative-ai/spec-driven-development-with-ai-get-started-with-a-new-open-source-toolkit/)
+- [METR: AI Impact on Experienced Developer Productivity](https://metr.org/blog/2025-07-10-early-2025-ai-experienced-os-dev-study/)
+- [GitHub: Lessons from 2,500+ AGENTS.md Files](https://github.blog/ai-and-ml/github-copilot/how-to-write-a-great-agents-md-lessons-from-over-2500-repositories/)
+- [Armin Ronacher: Agentic Coding Recommendations](https://lucumr.pocoo.org/2025/6/12/agentic-coding/)
+- [Addy Osmani: AI Coding Workflow](https://addyosmani.com/blog/ai-coding-workflow/)
+- [arXiv 2512.14012: Professional Developers Don't Vibe, They Control](https://arxiv.org/abs/2512.14012)

--- a/cotudes/ASE-000-setup/README.md
+++ b/cotudes/ASE-000-setup/README.md
@@ -1,0 +1,200 @@
+# ASE-000: Environment Setup
+
+> **This is the setup etude for the Associate Software Engineer path.**
+> There is no trap in this etude -- it is infrastructure.
+
+## Overview
+
+Before you can practice agent collaboration, you need a working environment.
+This etude walks you through setting up an AI coding agent, configuring your
+first project for agent interaction, and verifying that the feedback loops
+(tests, linters, type checker) work correctly.
+
+By the end of this setup, you will have:
+- A working AI coding agent (Claude Code, Codex, or equivalent)
+- A TypeScript project with tests, linting, and type checking
+- A basic CLAUDE.md / AGENTS.md file
+- Verified that the agent can run your build, tests, and lint commands
+
+## Prerequisites
+
+- Node.js 20+ installed
+- npm or pnpm installed
+- Git configured
+- A terminal you're comfortable in
+- Access to an AI coding agent (Claude Code recommended; Codex, Cursor, or
+  similar will work for most etudes)
+
+## Step 1: Install Your Agent
+
+### Claude Code (recommended)
+```bash
+npm install -g @anthropic-ai/claude-code
+```
+
+Verify:
+```bash
+claude --version
+```
+
+### Alternative Agents
+
+If using Codex, Jules, Cursor, or another agent, follow their installation
+instructions. The etudes are designed to be agent-agnostic -- the principles
+transfer.
+
+## Step 2: Create Your Practice Project
+
+Create a new TypeScript project that will serve as the codebase for the
+Associate SE path:
+
+```bash
+mkdir cotude-practice && cd cotude-practice
+npm init -y
+npm install typescript @types/node vitest eslint @typescript-eslint/eslint-plugin @typescript-eslint/parser --save-dev
+```
+
+Initialize TypeScript:
+```bash
+npx tsc --init --target ES2022 --module NodeNext --moduleResolution NodeNext --strict --outDir dist
+```
+
+Create the initial project structure:
+```
+cotude-practice/
+├── src/
+│   └── index.ts
+├── tests/
+│   └── index.test.ts
+├── package.json
+├── tsconfig.json
+└── eslint.config.js
+```
+
+### src/index.ts
+```typescript
+export function add(a: number, b: number): number {
+  return a + b;
+}
+```
+
+### tests/index.test.ts
+```typescript
+import { describe, it, expect } from 'vitest';
+import { add } from '../src/index';
+
+describe('add', () => {
+  it('adds two positive numbers', () => {
+    expect(add(2, 3)).toBe(5);
+  });
+
+  it('handles negative numbers', () => {
+    expect(add(-1, 1)).toBe(0);
+  });
+});
+```
+
+### package.json scripts
+Add these scripts to your package.json:
+```json
+{
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "eslint src/ tests/",
+    "check": "tsc --noEmit && eslint src/ tests/ && vitest run"
+  }
+}
+```
+
+## Step 3: Verify Your Feedback Loops
+
+Run each command and confirm it works:
+
+```bash
+npm run build     # Should compile without errors
+npm test          # Should pass 2 tests
+npm run lint      # Should report no issues
+npm run check     # Should pass all three checks
+```
+
+These commands are your **feedback loops**. When you work with an agent, the
+agent will use these commands to verify its own output. If these don't work, the
+agent is working blind.
+
+## Step 4: Create Your First CLAUDE.md
+
+Create a file called `CLAUDE.md` in the project root:
+
+```markdown
+# Project: cotude-practice
+
+## Commands
+- Build: `npm run build`
+- Test: `npm test`
+- Lint: `npm run lint`
+- Full check: `npm run check`
+
+## Stack
+- TypeScript (strict mode)
+- Vitest for testing
+- ESLint for linting
+
+## Conventions
+- All source code in `src/`
+- All tests in `tests/`, named `*.test.ts`
+- Use explicit return types on exported functions
+- Prefer `const` over `let`
+- No `any` types
+```
+
+This file will be read by your agent at the start of every session. It provides
+the persistent context that prevents the agent from guessing about your project's
+conventions.
+
+## Step 5: Verify Agent Integration
+
+Start your agent in the project directory:
+
+```bash
+cd cotude-practice
+claude   # or your agent's start command
+```
+
+Ask the agent to:
+1. Read the CLAUDE.md
+2. Run the tests
+3. Add a `multiply` function to `src/index.ts` with tests
+
+Verify that:
+- [ ] The agent found and read CLAUDE.md
+- [ ] The agent ran `npm test` (not a different test command)
+- [ ] The new function has an explicit return type
+- [ ] The tests are in the correct directory
+- [ ] `npm run check` passes after the agent's changes
+
+If all checkboxes pass, your environment is ready.
+
+## Step 6: Create Your Interaction Log
+
+Create a file called `interaction-log.md` in the project root. You'll use this
+throughout the Associate SE path to record your reflections on each etude.
+
+```markdown
+# Interaction Log
+
+## ASE-000: Setup
+- Date:
+- Agent used:
+- Notes:
+  - [What was your first impression of the agent?]
+  - [Did anything surprise you about how it interacted with the project?]
+  - [What questions do you have going into ASE-001?]
+```
+
+## What's Next
+
+You're ready for **ASE-001: The Vague Request**, where you'll learn why
+"build me a TODO app" is the most expensive sentence in agent-assisted
+development.

--- a/dev/best-practices.md
+++ b/dev/best-practices.md
@@ -1,0 +1,143 @@
+# cotudes Design Principles and Best Practices
+
+## 9 Design Principles
+
+### 1. Real Work, Not Toy Examples
+
+Every cotude must involve a genuine engineering task that produces working
+software. "Write a prompt for a TODO app" is not a cotude. "Build a REST API
+endpoint with proper error handling, test coverage, and documentation --
+collaborating with an agent using spec-driven development" is a cotude.
+
+### 2. The Trap Must Be Authentic
+
+The "trap" in each cotude must be a mistake that real practitioners actually
+make, as documented in practitioner literature. Fabricated traps that no one
+would actually fall into teach nothing. Every trap must be traceable to a
+documented anti-pattern.
+
+Trap severity scale:
+- **5 (Instinctive)**: Virtually every developer does this initially (e.g., vague prompting)
+- **4 (Common)**: Most developers without training make this mistake (e.g., no persistent context)
+- **3 (Intermediate)**: Experienced developers with some agent exposure still hit this (e.g., echo-chamber review)
+- **2 (Advanced)**: Only surfaces in complex workflows (e.g., parallel agent conflicts)
+- **1 (Subtle)**: Requires deep agent fluency to recognize (e.g., context window economics)
+
+### 3. One Primary Skill Per Etude
+
+Each cotude targets one primary competency from the 10 Core Competencies.
+Secondary competencies may be exercised, but the primary skill must be the clear
+focus. If an etude tries to teach specification writing AND parallel
+orchestration AND context engineering, it teaches none of them well.
+
+### 4. Respect the Learner's Expertise
+
+Cotudes are for engineers, not beginners. Associate-level etudes assume the
+learner knows how to code. Staff-level etudes assume deep technical expertise.
+Never condescend. The agent collaboration skill is new; their engineering
+knowledge is not.
+
+For Associate path: assume they know basic programming, data structures, and
+version control. Don't explain what a function is. Do explain what makes a
+specification effective.
+
+For Staff+ paths: assume they can architect systems, review code, and debug
+complex issues. Don't explain engineering fundamentals. Do challenge their
+assumptions about how their expertise should adapt to agent collaboration.
+
+### 5. Contrast Is the Teacher
+
+The most powerful learning moment in each cotude is the **contrast** between the
+ineffective approach (trap) and the effective approach (axiom in practice). Both
+approaches must be demonstrated on the same task so the learner can see the
+difference in outcome, not just be told about it.
+
+### 6. Axioms Must Be Memorable
+
+Each cotude produces one crisp axiom -- a principle the learner carries forward.
+These should be:
+- Concise (one sentence)
+- Actionable (directly applicable to future work)
+- Non-obvious (the learner wouldn't have guessed it before the exercise)
+
+Examples:
+- "Incremental decomposition with verification gates produces dramatically better
+  agent output than monolithic requests."
+- "The agent's context window is not a database -- every token you add competes
+  for attention."
+- "If you can't evaluate the output, you shouldn't delegate the task."
+
+### 7. Working Software Is the Measure
+
+An etude is not complete until working software exists. Not a plan. Not a
+conversation. Not a prompt template. Working, tested, reviewed code that the
+learner can explain and defend.
+
+### 8. The Interaction Is the Artifact
+
+Unlike traditional coding exercises where only the output matters, cotudes
+require the learner to preserve and annotate their agent interaction. The
+*process* of collaboration is as important as the product. This is the equivalent
+of showing your work in mathematics.
+
+### 9. Language and Tool Agnostic
+
+Core principles transfer across Claude Code, Codex, Jules, Antigravity, Cursor,
+and whatever comes next. Etudes may specify a tool for practical execution, but
+the axioms should not be tool-specific. If a principle only works with one
+specific agent, it's not a principle -- it's a workaround.
+
+## Quality Checklist
+
+### Requirement A (Agent Skill)
+
+- [ ] Does the etude target exactly one primary competency?
+- [ ] Is the trap authentic and documented in practitioner literature?
+- [ ] Does the contrast clearly demonstrate the superior approach?
+- [ ] Is the axiom concise, actionable, and non-obvious?
+- [ ] Would the skill transfer to a different agent tool?
+
+### Requirement B (Real Engineering)
+
+- [ ] Does the etude produce working, tested software?
+- [ ] Is the engineering task non-trivial?
+- [ ] Does the task match the target role's actual work?
+- [ ] Are success criteria clear and automatable?
+- [ ] Does the codebase context feel realistic?
+
+### Etude Structure
+
+- [ ] Metadata (path, number, competency, trap severity, prerequisites)
+- [ ] Overview (what the learner will build and learn)
+- [ ] The Setup (codebase context and task description)
+- [ ] The Trap (natural approach and its failure signal)
+- [ ] The Approach (effective agent collaboration pattern)
+- [ ] The Axiom (one-sentence principle)
+- [ ] Verification (how to confirm success)
+- [ ] Reflection Prompts (questions for the interaction log)
+
+## Coding Standards for Etude Codebases
+
+Etude starter codebases should:
+
+- Use strong typing (TypeScript over JavaScript, typed Python over untyped)
+- Include a working test suite (even if minimal)
+- Have clear build/run/test commands documented
+- Include a CLAUDE.md or equivalent context file
+- Be self-contained (no external service dependencies unless the etude is
+  specifically about that)
+- Use standard, well-known frameworks (not obscure libraries)
+- Compile and pass tests in the initial state
+
+## Anti-Patterns in Etude Design
+
+- **The Lecture**: An etude that is mostly explanation with a tiny exercise.
+  Ratio should be ≥60% doing, ≤40% reading.
+- **The Guessing Game**: An etude where the "correct" approach isn't clearly
+  superior -- the learner can't tell which worked better.
+- **The Tool Demo**: An etude that teaches a specific tool feature rather than a
+  transferable skill.
+- **The Perfection Trap**: An etude that implies there's one "correct" way to
+  interact with an agent. Multiple approaches can embody the same principle.
+- **The Island**: An etude with no connection to the learner's actual work.
+  Every etude should feel like something they'd encounter in their job.

--- a/dev/concept-coverage.md
+++ b/dev/concept-coverage.md
@@ -1,0 +1,105 @@
+# Concept Coverage Matrix
+
+## The 10 Core Competencies Across All Paths
+
+This document tracks which competencies are covered by which etudes, ensuring
+adequate coverage and identifying gaps.
+
+### Coverage Legend
+- **P** = Primary competency (the main focus of the etude)
+- **S** = Secondary competency (exercised but not the focus)
+- **-** = Not covered
+
+## Associate Software Engineer (ASE)
+
+| Etude | Spec Writing | Context Eng | Task Decomp | Delegation | Output Eval | Feedback Loop | Session Mgmt | Parallel | Recovery | Architecture |
+|-------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| ASE-001 | P | - | - | - | - | - | - | - | - | - |
+| ASE-002 | - | - | - | - | P | - | - | - | - | - |
+| ASE-003 | - | - | - | - | - | P | - | - | - | - |
+| ASE-004 | - | - | P | - | - | S | - | - | - | - |
+| ASE-005 | - | P | - | - | - | - | - | - | - | - |
+| ASE-006 | - | - | - | P | S | - | - | - | - | - |
+| ASE-007 | - | - | - | - | S | - | - | - | P | - |
+| ASE-008 | P | - | - | - | - | - | - | - | - | - |
+| ASE-009 | - | - | - | - | - | P | - | - | - | - |
+| ASE-010 | - | - | - | - | P | - | - | - | - | - |
+| ASE-011 | - | S | - | - | - | - | P | - | - | - |
+| ASE-012 | - | - | P | - | S | - | - | - | - | - |
+| ASE-013 | - | - | - | - | P | S | - | - | - | - |
+| ASE-014 | - | - | P | - | S | - | - | - | - | - |
+| ASE-015 | S | S | S | S | S | S | S | - | S | - |
+| **Total** | **2P** | **1P** | **3P** | **1P** | **3P** | **2P** | **1P** | **0** | **1P** | **0** |
+
+**Gap Analysis**: Parallel Orchestration and Architecture for Agents are not
+covered. This is intentional -- these are advanced competencies not appropriate
+for the Associate level.
+
+## Staff Software Engineer (STE)
+
+| Etude | Spec Writing | Context Eng | Task Decomp | Delegation | Output Eval | Feedback Loop | Session Mgmt | Parallel | Recovery | Architecture |
+|-------|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| STE-001 | - | P | - | - | - | - | S | - | - | - |
+| STE-002 | P | - | - | - | - | - | - | - | - | - |
+| STE-003 | - | - | - | P | - | - | - | - | - | - |
+| STE-004 | - | P | - | - | - | - | - | - | - | - |
+| STE-005 | - | - | - | - | - | - | - | P | - | - |
+| STE-006 | - | - | - | - | - | - | - | - | - | P |
+| STE-007 | - | - | - | - | P | - | - | - | - | - |
+| STE-008 | - | - | - | - | - | - | - | - | P | - |
+| STE-009 | - | - | - | - | - | P | - | - | - | - |
+| STE-010 | - | S | - | - | - | - | P | - | - | - |
+| STE-011 | - | - | P | - | - | - | - | - | - | - |
+| STE-012 | - | P | - | - | - | - | - | - | - | - |
+| STE-013 | - | - | - | - | P | - | - | - | - | - |
+| STE-014 | - | - | - | P | - | - | - | - | - | - |
+| STE-015 | S | S | S | S | S | S | S | S | S | S |
+| **Total** | **1P** | **3P** | **1P** | **2P** | **2P** | **1P** | **1P** | **1P** | **1P** | **1P** |
+
+**Gap Analysis**: Full coverage across all 10 competencies.
+
+## Cross-Path Coverage Summary
+
+| Competency | ASE | STE | PSE | PSA | DOE | DME |
+|-----------|:---:|:---:|:---:|:---:|:---:|:---:|
+| Specification Writing | 2P | 1P | - | 1P | - | 2P |
+| Context Engineering | 1P | 3P | 1P | 1P | 1P | 1P |
+| Task Decomposition | 3P | 1P | - | 1P | 1P | - |
+| Delegation Judgment | 1P | 2P | 2P | 1P | 1P | - |
+| Output Evaluation | 3P | 2P | 3P | 1P | 2P | 3P |
+| Feedback Loop Design | 2P | 1P | - | 1P | 3P | 1P |
+| Session Management | 1P | 1P | - | - | - | - |
+| Parallel Orchestration | - | 1P | - | - | - | - |
+| Recovery Patterns | 1P | 1P | - | - | 1P | 1P |
+| Architecture for Agents | - | 1P | 1P | 3P | 1P | 1P |
+
+**Observations**:
+- Output Evaluation is heavily covered across all paths -- this is appropriate
+  as it's the most universally critical skill
+- Parallel Orchestration is only explicitly covered in the Staff SE path -- this
+  is intentional (it's an advanced pattern)
+- Session Management is only covered in ASE and STE -- consider adding coverage
+  in longer-running paths (Architect, DevOps)
+- Architecture for Agents scales from absent (ASE) to dominant (PSA) -- this
+  correctly reflects role progression
+
+## Competency Dependency Graph
+
+```
+Specification Writing ─────────────────────────────────── Foundation
+        │
+Context Engineering ──────── Session Management            │
+        │                          │                       │
+Task Decomposition                 │                       │
+        │                          │                       │
+Delegation Judgment ──────── Parallel Orchestration         │
+        │                                                  │
+Output Evaluation ────────── Recovery Patterns              │
+        │                                                  │
+Feedback Loop Design                                       │
+        │                                                  │
+Architecture for Agents ──────────────────────────────── Advanced
+```
+
+Specification Writing and Output Evaluation are foundational -- every other
+competency builds on the ability to specify intent and evaluate results.

--- a/dev/curriculum-map.md
+++ b/dev/curriculum-map.md
@@ -1,0 +1,334 @@
+# cotudes Curriculum Map
+
+## Philosophy
+
+The name **cotudes** (co + etudes) follows the tradition of Peter Norvig's
+[pytudes](https://github.com/norvig/pytudes) and
+[cpptudes](https://github.com/coreyt/cpptudes), themselves inspired by Charles
+Wetherell's 1978 book *Etudes for Programmers*. An etude is a musical exercise
+designed to develop a specific technical skill through deliberate practice.
+
+Each **cotude** is a structured coding exercise designed to develop a specific
+skill for working effectively with an agentic coding partner. The exercises
+involve real engineering tasks -- not toy examples -- where the learner must
+collaborate with an AI agent to produce working software.
+
+## Core Thesis
+
+Knowing how to use a tool is easy. Knowing how to *collaborate effectively* with
+an autonomous coding agent is a distinct skill set that must be developed through
+practice. Just as cpptudes targets C# habits that fail in C++, cotudes targets
+**solo-coding habits that fail with agents**.
+
+The hard part is not learning commands or prompts. It is:
+
+- Shifting from **code writer** to **engineering director**
+- Learning when to delegate and when to intervene
+- Developing judgment about agent output quality
+- Building workflows that compound agent effectiveness
+
+## Pedagogical Model: Trap-Then-Correct
+
+Adapted from cpptudes, each cotude follows a deliberate pattern:
+
+1. **Bait** -- A real coding task structured so the learner's natural
+   solo-coding instinct leads to an ineffective agent interaction
+2. **Failure Signal** -- The agent produces poor output, goes in circles, burns
+   excessive tokens, or takes far longer than necessary
+3. **Contrast** -- A well-structured interaction approach is demonstrated that
+   produces dramatically better results on the same task
+4. **Axiom** -- The underlying principle of effective agent collaboration is
+   articulated
+
+### Example
+
+**Cotude: "The Monolith Prompt"**
+- Bait: Learner is given a moderately complex feature to implement. Their instinct
+  is to describe the entire feature in one prompt.
+- Failure Signal: Agent produces a 500-line monolithic output with subtle bugs,
+  inconsistencies, and code that doesn't integrate with the existing codebase.
+- Contrast: Same feature, decomposed into 6 sequential prompts with incremental
+  verification. Each step builds on tested, working code.
+- Axiom: **Incremental decomposition with verification gates produces
+  dramatically better agent output than monolithic requests.**
+
+## Dual Requirement Framework
+
+Every cotude must satisfy both requirements:
+
+- **Requirement A (Agent Skill)**: The etude must teach a genuine, transferable
+  agent collaboration skill that practitioners have identified as critical.
+- **Requirement B (Real Engineering)**: The etude must involve a real, non-trivial
+  coding task. The learner must produce working software, not just practice
+  prompting in the abstract.
+
+Neither requirement is optional. An etude that teaches prompting through toy
+examples fails Requirement B. An etude that is just a coding exercise without
+agent collaboration patterns fails Requirement A.
+
+## The 10 Core Competencies
+
+Derived from practitioner experience across Claude Code, Codex, Jules, and
+Antigravity, these are the skills that distinguish effective agent collaborators:
+
+| # | Competency | Description | Importance |
+|---|-----------|-------------|------------|
+| 1 | **Specification Writing** | Writing clear specs before prompting. Defining what, why, how, and constraints. | Critical |
+| 2 | **Context Engineering** | Providing the right information at the right time. CLAUDE.md, targeted context, avoiding overload. | Critical |
+| 3 | **Task Decomposition** | Breaking work into agent-sized pieces with verification gates between steps. | Critical |
+| 4 | **Delegation Judgment** | Knowing what to delegate vs. do yourself. Matching task characteristics to agent strengths. | Critical |
+| 5 | **Output Evaluation** | Reviewing agent-generated code critically. Catching subtle errors, hallucinations, and silent failures. | Critical |
+| 6 | **Feedback Loop Design** | Using tests, linters, type checkers, and CI as automated agent guardrails. | High |
+| 7 | **Session Management** | Maintaining state across sessions. Persistent context, knowing when to start fresh. | High |
+| 8 | **Parallel Orchestration** | Running multiple agent workflows on independent tasks. Managing cognitive overhead. | Medium |
+| 9 | **Recovery Patterns** | Handling agent failures, circular reasoning, and dead ends. Knowing when to abandon. | High |
+| 10 | **Architecture for Agents** | Designing systems that are agent-friendly: simple patterns, explicit types, good test coverage. | High |
+
+## The 6 Learning Paths
+
+Each path targets a specific engineering role with etudes calibrated to their
+experience level, daily responsibilities, and unique challenges.
+
+### Path 1: Associate Software Engineer (16 etudes)
+
+**Profile**: 0-2 years experience. Learning both software engineering and agent
+collaboration simultaneously. May not yet have strong instincts about what "good
+code" looks like.
+
+**Unique Challenge**: They need to develop engineering judgment *and* agent
+collaboration skills in parallel, without letting the agent become a crutch that
+prevents learning fundamentals.
+
+**Primary Competencies**: Specification Writing, Task Decomposition, Output
+Evaluation, Feedback Loop Design
+
+**Etude Sequence**:
+
+| # | Title | Competency | Trap |
+|---|-------|-----------|------|
+| ASE-000 | Environment Setup | Setup | None -- infrastructure |
+| ASE-001 | The Vague Request | Specification Writing | Asking "build me a TODO app" with no spec |
+| ASE-002 | Reading Before Writing | Output Evaluation | Accepting first output without review |
+| ASE-003 | The Test First | Feedback Loop Design | Writing code without tests, then debugging blind |
+| ASE-004 | One Bite at a Time | Task Decomposition | Requesting an entire feature in one prompt |
+| ASE-005 | The Missing Context | Context Engineering | Agent hallucinating APIs because it lacks project context |
+| ASE-006 | Know What You Don't Know | Delegation Judgment | Delegating a task you can't evaluate |
+| ASE-007 | The Debug Loop | Recovery Patterns | Letting the agent loop on its own errors |
+| ASE-008 | The Specification | Specification Writing | Converting requirements to a structured spec |
+| ASE-009 | Type Safety Net | Feedback Loop Design | Untyped code producing subtle runtime errors |
+| ASE-010 | The Code Review | Output Evaluation | Systematic review of agent-generated code |
+| ASE-011 | Building on Foundation | Session Management | Context loss between sessions |
+| ASE-012 | The Refactor | Task Decomposition | Refactoring without incremental verification |
+| ASE-013 | Edge Cases | Output Evaluation | Agent-generated code missing boundary conditions |
+| ASE-014 | The Integration | Task Decomposition | Integrating agent code into existing systems |
+| ASE-015 | Capstone: Feature Build | All | End-to-end feature using all competencies |
+
+### Path 2: Staff Software Engineer (16 etudes)
+
+**Profile**: 8+ years experience. Deep technical skills. Leads technical
+direction for a team. Years of solo-coding muscle memory to override.
+
+**Unique Challenge**: Their expertise makes them faster at writing code than
+reviewing agent output, creating resistance to adoption. The METR study found
+experienced developers initially took 19% longer with agents.
+
+**Primary Competencies**: Context Engineering, Parallel Orchestration, Delegation
+Judgment, Architecture for Agents
+
+**Etude Sequence**:
+
+| # | Title | Competency | Trap |
+|---|-------|-----------|------|
+| STE-000 | Environment Setup | Setup | None -- infrastructure |
+| STE-001 | The CLAUDE.md | Context Engineering | No persistent context; same corrections every session |
+| STE-002 | Spec-Driven Development | Specification Writing | Jumping to code without a spec |
+| STE-003 | The Delegation Matrix | Delegation Judgment | Delegating design decisions; keeping typing |
+| STE-004 | Context Window Economics | Context Engineering | Overloading context; signal drowned by noise |
+| STE-005 | The Parallel Sprint | Parallel Orchestration | Running 5 agents on interdependent tasks |
+| STE-006 | Agent-Friendly Architecture | Architecture for Agents | Clever abstractions that confuse agents |
+| STE-007 | The Review Protocol | Output Evaluation | Reviewing AI output with AI (echo chamber) |
+| STE-008 | Recovery and Restart | Recovery Patterns | Sunk-cost fallacy on a failing agent thread |
+| STE-009 | The Feedback Machine | Feedback Loop Design | CI pipeline as agent iteration loop |
+| STE-010 | Session Continuity | Session Management | Multi-day features across session boundaries |
+| STE-011 | The Migration | Task Decomposition | Large codebase migration with agents |
+| STE-012 | Cross-Cutting Concerns | Context Engineering | Agent unaware of system-wide constraints |
+| STE-013 | The Performance Review | Output Evaluation | Evaluating non-functional agent output quality |
+| STE-014 | Team Patterns | Delegation Judgment | Establishing agent practices for a team |
+| STE-015 | Capstone: System Feature | All | End-to-end system feature across multiple services |
+
+### Path 3: Principal Software Engineer (12 etudes)
+
+**Profile**: 12+ years experience. Sets technical direction across multiple
+teams. Evaluates architectural trade-offs. Responsible for long-term code health.
+
+**Unique Challenge**: Must make decisions about agent adoption that affect entire
+organizations, with limited historical precedent. Must balance productivity gains
+against maintainability and skill development risks.
+
+**Primary Competencies**: Architecture for Agents, Delegation Judgment, Output
+Evaluation, Context Engineering
+
+**Etude Sequence**:
+
+| # | Title | Competency | Trap |
+|---|-------|-----------|------|
+| PSE-000 | Environment Setup | Setup | None -- infrastructure |
+| PSE-001 | The Architecture Review | Architecture for Agents | Reviewing agent-proposed architecture uncritically |
+| PSE-002 | Technical Debt Triage | Output Evaluation | Agent code that works but accumulates debt |
+| PSE-003 | The Standards Document | Context Engineering | Writing agent guidelines that are too vague or too rigid |
+| PSE-004 | Measuring Agent ROI | Delegation Judgment | Measuring lines-of-code instead of outcomes |
+| PSE-005 | The Legacy System | Architecture for Agents | Agent struggling with undocumented legacy code |
+| PSE-006 | Design Review Protocol | Output Evaluation | Establishing review standards for agent output |
+| PSE-007 | The Prototype vs. Production | Delegation Judgment | Agent prototype mistaken for production-ready code |
+| PSE-008 | Cross-Team Consistency | Context Engineering | Different teams using agents with incompatible patterns |
+| PSE-009 | The Skill Preservation | Delegation Judgment | Team skills atrophying from over-reliance |
+| PSE-010 | Security Surface Review | Output Evaluation | Agent-introduced vulnerabilities in subtle patterns |
+| PSE-011 | Capstone: Org-Wide Practice | All | Establishing agent practices across an engineering org |
+
+### Path 4: Principal Software Architect (12 etudes)
+
+**Profile**: 15+ years experience. Responsible for system design decisions that
+span years and teams. Evaluates technology strategy.
+
+**Unique Challenge**: Architectural decisions made now must account for rapidly
+evolving agent capabilities. Over-optimizing for current agents may be as
+costly as ignoring them entirely.
+
+**Primary Competencies**: Architecture for Agents, Context Engineering,
+Delegation Judgment, Specification Writing
+
+**Etude Sequence**:
+
+| # | Title | Competency | Trap |
+|---|-------|-----------|------|
+| PSA-000 | Environment Setup | Setup | None -- infrastructure |
+| PSA-001 | Agent-Friendly System Design | Architecture for Agents | System with implicit knowledge that agents can't discover |
+| PSA-002 | The Specification as Contract | Specification Writing | ADRs and RFCs that agents can consume and implement |
+| PSA-003 | Modular Boundaries | Architecture for Agents | Designing module boundaries for agent-sized work units |
+| PSA-004 | The Evolutionary Architecture | Architecture for Agents | Designing for agent capabilities that don't exist yet |
+| PSA-005 | Documentation as Code | Context Engineering | Self-documenting architecture for both humans and agents |
+| PSA-006 | The Platform Decision | Delegation Judgment | Evaluating build-with-agent vs. buy vs. build-yourself |
+| PSA-007 | Observability Design | Feedback Loop Design | Monitoring agent-generated system behavior |
+| PSA-008 | The Data Architecture | Architecture for Agents | Schema design that agents can reason about |
+| PSA-009 | Compliance and Governance | Output Evaluation | Ensuring agent output meets regulatory requirements |
+| PSA-010 | The Migration Strategy | Task Decomposition | Planning large-scale migrations for agent execution |
+| PSA-011 | Capstone: System Redesign | All | Redesigning a system with agent collaboration in mind |
+
+### Path 5: Staff DevOps / CI/CD Engineer (12 etudes)
+
+**Profile**: 8+ years experience in infrastructure, deployment, and operational
+systems. Responsible for the pipelines that all code -- including agent-generated
+code -- flows through.
+
+**Unique Challenge**: Infrastructure mistakes can be catastrophic and difficult
+to reverse. Agent-generated IaC must be reviewed with extreme care. The DevOps
+engineer also builds the feedback loops that make agents effective for everyone.
+
+**Primary Competencies**: Feedback Loop Design, Output Evaluation, Context
+Engineering, Architecture for Agents
+
+**Etude Sequence**:
+
+| # | Title | Competency | Trap |
+|---|-------|-----------|------|
+| DOE-000 | Environment Setup | Setup | None -- infrastructure |
+| DOE-001 | The CI Feedback Loop | Feedback Loop Design | CI that reports pass/fail but no actionable detail |
+| DOE-002 | IaC with Agents | Output Evaluation | Agent-generated Terraform with security misconfigs |
+| DOE-003 | Pipeline as Agent Guardrail | Feedback Loop Design | Designing CI stages that catch agent mistakes |
+| DOE-004 | The Dockerfile | Context Engineering | Agent building images without understanding constraints |
+| DOE-005 | Security Scanning | Output Evaluation | Hallucinated dependencies and supply-chain risks |
+| DOE-006 | The Deployment Strategy | Task Decomposition | Agent-assisted rollout with incremental verification |
+| DOE-007 | Monitoring and Alerting | Feedback Loop Design | Agent-generated monitoring that misses critical signals |
+| DOE-008 | The Incident Response | Recovery Patterns | Using agents during incidents (speed vs. risk) |
+| DOE-009 | Platform Engineering | Architecture for Agents | Building internal platforms that agents can operate |
+| DOE-010 | Cost and Resource Management | Delegation Judgment | Agent-provisioned resources without cost awareness |
+| DOE-011 | Capstone: Pipeline Overhaul | All | End-to-end CI/CD redesign for agent-augmented teams |
+
+### Path 6: Staff Data Management Engineer (12 etudes)
+
+**Profile**: 8+ years in data engineering, database administration, or data
+platform work. Responsible for schemas, pipelines, data quality, and governance.
+
+**Unique Challenge**: Data correctness is harder to verify than code correctness.
+A function that compiles and passes tests might still silently corrupt data.
+Agent-generated SQL or pipeline code requires domain-specific review that goes
+beyond syntax checking.
+
+**Primary Competencies**: Output Evaluation, Specification Writing, Feedback Loop
+Design, Context Engineering
+
+**Etude Sequence**:
+
+| # | Title | Competency | Trap |
+|---|-------|-----------|------|
+| DME-000 | Environment Setup | Setup | None -- infrastructure |
+| DME-001 | The Schema Design | Specification Writing | Agent-designed schema missing domain constraints |
+| DME-002 | Migration Safety | Output Evaluation | Agent-generated migration that loses data silently |
+| DME-003 | The Query Review | Output Evaluation | Agent SQL that returns results but is subtly wrong |
+| DME-004 | Pipeline Specification | Specification Writing | Vague ETL requirements producing fragile pipelines |
+| DME-005 | Data Quality Gates | Feedback Loop Design | Pipelines without data validation checkpoints |
+| DME-006 | The Context Problem | Context Engineering | Agent unaware of data lineage and dependencies |
+| DME-007 | Idempotency and Recovery | Recovery Patterns | Agent pipelines that can't safely re-run |
+| DME-008 | Performance at Scale | Output Evaluation | Agent queries that work on dev but fail at prod scale |
+| DME-009 | The Access Pattern | Architecture for Agents | Designing data APIs that agents can reason about |
+| DME-010 | Data Governance | Specification Writing | Ensuring agent output respects PII and retention policies |
+| DME-011 | Capstone: Data Platform | All | End-to-end data platform feature with agent collaboration |
+
+## Prerequisite Dependencies
+
+### Within Each Path
+
+```
+000 (Setup) → 001-003 (Foundation) → 004-007 (Fluency) → 008-011+ (Application) → Capstone
+```
+
+Foundation etudes must be completed before Fluency. Fluency before Application.
+Capstones require all prior etudes in the path.
+
+### Cross-Path Prerequisites
+
+None required. Each path is self-contained. However, recommended cross-training:
+
+- Staff Engineers benefit from completing ASE-001 through ASE-005 first (as a
+  humility check -- the basics still apply)
+- Principal Engineers should complete at least one path's Foundation tier
+- Architects should complete STE-006 (Agent-Friendly Architecture) from the
+  Staff path
+
+## Assessment Model
+
+Each etude produces two artifacts:
+
+1. **The Code** -- Working software produced through agent collaboration
+2. **The Interaction Log** -- The actual conversation/session with the agent,
+   annotated by the learner with reflections on what worked and what didn't
+
+Assessment criteria:
+
+- Did the learner identify and avoid the trap?
+- Does the code meet the engineering requirements?
+- Did the agent interaction demonstrate the target competency?
+- Can the learner articulate the underlying principle (axiom)?
+
+## Technology Stack
+
+Cotudes are **language-agnostic by design**. The agent collaboration skills
+transfer across any language or framework. However, each etude specifies a
+recommended stack chosen for:
+
+1. **Agent-friendliness** -- Languages with strong type systems and fast feedback
+   loops (Go, TypeScript, Rust, typed Python) are preferred
+2. **Relevance to the role** -- DevOps etudes use Terraform/Docker/YAML; Data
+   etudes use SQL/Python/dbt
+3. **Verifiability** -- Every etude must have clear, automatable success criteria
+
+## Sources
+
+This curriculum is informed by practitioner experience documented in:
+
+- Anthropic's context engineering research
+- The METR randomized controlled trial on AI-assisted development
+- GitHub's analysis of 2,500+ AGENTS.md files
+- Spec-driven development practices (GitHub Spec-Kit, Thoughtworks)
+- Practitioner reports from Addy Osmani, Armin Ronacher, Boris Cherny, and others
+- The "Professional Software Developers Don't Vibe, They Control" study (arXiv 2512.14012)

--- a/dev/draft-prompts.md
+++ b/dev/draft-prompts.md
@@ -1,0 +1,165 @@
+# Etude Authoring Pipeline
+
+## Overview
+
+This document defines the multi-agent pipeline for creating new cotudes. It
+mirrors the approach used in cpptudes: multiple specialist agents contribute
+their expertise, then a writer synthesizes the inputs into the final etude.
+
+## The 6-Stage Pipeline
+
+### Stage 1: Curriculum Designer → Etude Specification
+**Input**: The path, etude number, target competency, and trap from the curriculum map.
+**Output**: A complete etude specification (see curriculum-designer agent for format).
+
+The curriculum designer produces the blueprint: what the learner builds, what
+trap they'll encounter, what the effective approach looks like, and what axiom
+emerges.
+
+### Stage 2: Agent Expert → Agent Behavior Analysis
+**Input**: The etude specification from Stage 1.
+**Output**: Requirement A analysis -- detailed assessment of the trap's
+authenticity, the skill's transferability, and the axiom's accuracy.
+
+The agent expert validates that the trap is a real, documented anti-pattern and
+that the effective approach actually works with current agents.
+
+### Stage 3: Engineering Practice Expert → Engineering Context Analysis
+**Input**: The etude specification from Stage 1.
+**Output**: Requirement B analysis -- detailed assessment of the engineering
+task's realism, the role-appropriate complexity, and the starter codebase design.
+
+The engineering practice expert validates that the task is real work for the
+target role and that the starter codebase is sound.
+
+**Stages 2 and 3 run in parallel.** Both receive Stage 1 output and work
+independently.
+
+### Stage 4: Etude Writer → Complete Cotude
+**Input**: Outputs from Stages 1, 2, and 3.
+**Output**: The complete cotude directory: README.md, starter codebase,
+reference solution, and verification script.
+
+The etude writer synthesizes all expert inputs into the final learning
+experience.
+
+### Stage 5: Agent Expert → Requirement A Review
+**Input**: The complete cotude from Stage 4.
+**Output**: PASS, NEEDS REVISION, or FAIL verdict with specific issues.
+
+### Stage 6: Engineering Practice Expert → Requirement B Review
+**Input**: The complete cotude from Stage 4.
+**Output**: PASS, NEEDS REVISION, or FAIL verdict with specific issues.
+
+**Stages 5 and 6 run in parallel.**
+
+### Revision Loop
+
+If either review fails:
+1. The etude writer receives the specific issues from the failing review(s)
+2. The writer produces a targeted revision
+3. Only the failing review stage(s) re-run
+4. Maximum 2 revision cycles -- if still failing, escalate to curriculum designer
+   for specification adjustment
+
+## Stage Prompts
+
+### Stage 1 Prompt (Curriculum Designer)
+
+```
+You are the Curriculum Designer for cotudes. Using the curriculum map, produce
+a complete etude specification for:
+
+Path: [PATH]
+Etude: [NUMBER]
+Title: [TITLE]
+Primary Competency: [COMPETENCY]
+Trap: [TRAP DESCRIPTION]
+
+Follow the specification format defined in your agent definition. Ensure both
+Requirement A (agent skill) and Requirement B (real engineering) are addressed
+in the specification.
+
+Reference the curriculum map (dev/curriculum-map.md) and the relevant path
+document (paths/[path].md) for context on sequencing and prerequisites.
+```
+
+### Stage 2 Prompt (Agent Expert)
+
+```
+You are the Agent Expert for cotudes. Review the following etude specification
+for Requirement A compliance:
+
+[SPECIFICATION FROM STAGE 1]
+
+Produce a complete Requirement A analysis following the format in your skill
+definition. Specifically assess:
+- Is the trap a documented anti-pattern? Cite your source.
+- Rate trap severity 1-5 with justification.
+- Does the skill transfer across different agent tools?
+- Is the axiom supported by practitioner evidence?
+```
+
+### Stage 3 Prompt (Engineering Practice Expert)
+
+```
+You are the Engineering Practice Expert for cotudes. Review the following etude
+specification for Requirement B compliance:
+
+[SPECIFICATION FROM STAGE 1]
+
+Produce a complete Requirement B analysis following the format in your skill
+definition. Specifically assess:
+- Would someone in the [ROLE] role encounter this task?
+- Is the complexity appropriate for the experience level?
+- Are acceptance criteria clear and automatable?
+- What specific solo-coding instinct triggers the trap?
+```
+
+### Stage 4 Prompt (Etude Writer)
+
+```
+You are the Etude Writer for cotudes. Synthesize the following inputs into a
+complete cotude:
+
+SPECIFICATION:
+[OUTPUT FROM STAGE 1]
+
+AGENT BEHAVIOR ANALYSIS:
+[OUTPUT FROM STAGE 2]
+
+ENGINEERING CONTEXT ANALYSIS:
+[OUTPUT FROM STAGE 3]
+
+Produce the complete cotude directory following the template in your agent
+definition. Ensure:
+- The README follows the structural template exactly
+- The starter codebase compiles and passes tests
+- The trap is NOT revealed in Part 1
+- The contrast between Part 1 and Part 2 is dramatic and measurable
+- Reflection prompts are specific, comparative, metacognitive, and forward-looking
+```
+
+### Stage 5-6 Review Prompts
+
+```
+You are the [Agent Expert / Engineering Practice Expert] for cotudes. Review
+the following complete cotude for Requirement [A / B] compliance:
+
+[COMPLETE COTUDE FROM STAGE 4]
+
+Produce a verdict: PASS, NEEDS REVISION, or FAIL.
+If not PASS, list specific issues that must be addressed.
+```
+
+## Pipeline Execution
+
+For a single etude:
+```
+Stage 1 → [Stage 2 + Stage 3 in parallel] → Stage 4 → [Stage 5 + Stage 6 in parallel]
+```
+
+For batch creation (multiple etudes in a path):
+- Stages 1-3 for all etudes can run in parallel
+- Stage 4 should run sequentially to maintain voice consistency
+- Stages 5-6 can run in parallel across etudes

--- a/paths/associate-software-engineer.md
+++ b/paths/associate-software-engineer.md
@@ -1,0 +1,150 @@
+# Path: Associate Software Engineer
+
+## Profile
+
+**Experience**: 0-2 years. Early-career engineers learning both software
+engineering and agent collaboration simultaneously.
+
+**Daily Work**: Implementing features within established patterns. Writing tests.
+Fixing bugs. Reviewing PRs from peers. Working within a single service or
+component.
+
+**Unique Challenge**: Must develop engineering judgment and agent collaboration
+skills in parallel. The risk is that the agent becomes a crutch that prevents
+learning fundamentals -- the learner ships working code without understanding why
+it works.
+
+**Anti-goal**: An associate who can "get the agent to produce code" but can't
+explain the code, debug it when it breaks, or recognize when it's subtly wrong.
+
+## Primary Competencies
+
+1. **Specification Writing** -- Learning to externalize requirements before coding
+2. **Task Decomposition** -- Breaking features into agent-sized pieces
+3. **Output Evaluation** -- Critically reviewing agent-generated code
+4. **Feedback Loop Design** -- Using tests and types as guardrails
+
+## Etude Sequence
+
+### Foundation (ASE-001 to ASE-003)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| ASE-001 | The Vague Request | Specification Writing | Asking "build me a TODO app" with no spec (5) | TypeScript |
+| ASE-002 | Reading Before Writing | Output Evaluation | Accepting first agent output without review (5) | TypeScript |
+| ASE-003 | The Test First | Feedback Loop Design | Writing code without tests, debugging blind (4) | TypeScript |
+
+**ASE-001: The Vague Request**
+The learner is asked to build a REST API endpoint. Their instinct is to describe
+it in one sentence to the agent. The agent produces something that "works" but
+makes wrong assumptions about validation, error codes, data types, and edge
+cases. The contrast: the same task with a structured specification (inputs,
+outputs, error cases, constraints) produces dramatically better code. **Axiom:
+Agents don't read your mind -- the spec IS the product.**
+
+**ASE-002: Reading Before Writing**
+The learner receives agent-generated code for a data processing function. It
+passes the existing tests. Their instinct is to accept it. The checkpoint reveals
+subtle issues: an O(n²) loop where O(n) is possible, missing null checks at
+the API boundary, and a variable name that misleads about its contents. The
+contrast: systematic review with a checklist catches all three issues before
+they become bugs. **Axiom: If you didn't write it, you must read it twice as
+carefully.**
+
+**ASE-003: The Test First**
+The learner is asked to add a feature to an existing module. Their instinct is
+to describe the feature and let the agent write code + tests together. The agent
+produces code that passes its own tests -- but the tests are weak (happy path
+only, no edge cases). The contrast: writing tests first (specifying behavior
+before implementation) produces better tests AND better code. **Axiom: Tests
+written after implementation verify what was built; tests written before
+implementation specify what should be built.**
+
+### Fluency (ASE-004 to ASE-007)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| ASE-004 | One Bite at a Time | Task Decomposition | Requesting entire feature in one prompt (5) | TypeScript |
+| ASE-005 | The Missing Context | Context Engineering | Agent hallucinating APIs lacking project context (4) | TypeScript |
+| ASE-006 | Know What You Don't Know | Delegation Judgment | Delegating a task you can't evaluate (3) | TypeScript |
+| ASE-007 | The Debug Loop | Recovery Patterns | Letting agent loop on its own errors (4) | TypeScript |
+
+**ASE-004: One Bite at a Time**
+A moderately complex feature (user authentication with JWT, refresh tokens,
+and role-based access). The learner's instinct is to describe all of it at once.
+The agent produces a monolithic blob with inconsistencies between components.
+The contrast: decomposed into 5 sequential steps, each verified before
+proceeding, producing clean, integrated code. **Axiom: An agent working on a
+verified foundation builds higher than one working on assumptions.**
+
+**ASE-005: The Missing Context**
+The learner works in a codebase with established patterns (specific ORM usage,
+custom error handling middleware, naming conventions). Without being told, the
+agent invents its own patterns that clash with the existing code. The contrast:
+providing a CLAUDE.md with project conventions produces code that fits
+seamlessly. **Axiom: The agent's default is to invent; your job is to constrain.**
+
+**ASE-006: Know What You Don't Know**
+The learner is asked to implement a caching layer. They have no experience with
+caching. Their instinct is to delegate the entire design to the agent. The agent
+produces a solution using patterns the learner can't evaluate (cache
+invalidation strategy, TTL decisions, race conditions). The contrast: researching
+caching fundamentals first, then collaborating with the agent on implementation
+details. **Axiom: If you can't evaluate the output, you shouldn't delegate
+the task -- delegate the research first.**
+
+**ASE-007: The Debug Loop**
+A function the agent wrote has a bug. The learner describes the bug to the agent.
+The agent "fixes" it by changing something that introduces a new bug. The learner
+reports the new bug. The agent reverts to the original. This loops. The contrast:
+the learner diagnoses the root cause themselves, provides a precise description,
+and the agent fixes it in one pass. **Axiom: Agents fix symptoms; engineers
+diagnose root causes.**
+
+### Application (ASE-008 to ASE-014)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| ASE-008 | The Specification | Specification Writing | Requirements → structured spec conversion (3) | TypeScript |
+| ASE-009 | Type Safety Net | Feedback Loop Design | Untyped code producing subtle runtime errors (4) | TypeScript → Python |
+| ASE-010 | The Code Review | Output Evaluation | Systematic review of multi-file agent output (3) | TypeScript |
+| ASE-011 | Building on Foundation | Session Management | Context loss between sessions (4) | TypeScript |
+| ASE-012 | The Refactor | Task Decomposition | Refactoring without incremental verification (3) | TypeScript |
+| ASE-013 | Edge Cases | Output Evaluation | Agent code missing boundary conditions (3) | TypeScript |
+| ASE-014 | The Integration | Task Decomposition | Integrating agent code into existing systems (3) | TypeScript |
+
+### Capstone (ASE-015)
+
+| # | Title | Competency | Trap | Stack |
+|---|-------|-----------|------|-------|
+| ASE-015 | Feature Build | All | End-to-end feature using all competencies | TypeScript |
+
+The capstone requires the learner to build a complete feature from requirements
+through deployment-ready code, using all competencies learned in the path. They
+must produce both working code and an annotated interaction log demonstrating
+effective agent collaboration at each stage.
+
+## Prerequisites
+
+```
+ASE-000 (Setup)
+    └── ASE-001 (Specification Writing)
+    └── ASE-002 (Output Evaluation)
+    └── ASE-003 (Feedback Loops)
+            └── ASE-004 (Task Decomposition)
+            └── ASE-005 (Context Engineering)
+            └── ASE-006 (Delegation Judgment)
+            └── ASE-007 (Recovery Patterns)
+                    └── ASE-008 through ASE-014 (Application)
+                            └── ASE-015 (Capstone)
+```
+
+## Assessment Criteria
+
+For each etude, the learner demonstrates competency by:
+
+1. **Experiencing the trap** -- They must attempt Part 1 and see the failure
+2. **Applying the approach** -- Part 2 produces measurably better results
+3. **Articulating the axiom** -- They can explain the principle in their own words
+4. **Producing working code** -- The software meets acceptance criteria
+5. **Reflecting on the process** -- Interaction log shows metacognitive awareness

--- a/paths/principal-software-architect.md
+++ b/paths/principal-software-architect.md
@@ -1,0 +1,91 @@
+# Path: Principal Software Architect
+
+## Profile
+
+**Experience**: 15+ years. Responsible for system design decisions that span
+years and teams. Evaluates technology strategy and makes bets on where the
+industry is heading.
+
+**Daily Work**: System architecture design, architecture decision records (ADRs),
+bounded context definition, service boundary design, technology evaluation,
+capacity planning, API strategy, compliance architecture.
+
+**Unique Challenge**: Architectural decisions made now must account for rapidly
+evolving agent capabilities. Over-optimizing for current agent limitations may be
+as costly as ignoring agents entirely. The time horizon for architecture is 3-5
+years; agent capabilities are changing quarterly.
+
+**Anti-goal**: An architect who designs systems without considering that agents
+will be primary authors of the code within those systems, or one who warps
+architecture around current agent quirks that will be obsolete in 18 months.
+
+## Primary Competencies
+
+1. **Architecture for Agents** -- Designing systems agents can understand and extend
+2. **Context Engineering** -- Self-documenting architecture for humans and agents
+3. **Delegation Judgment** -- Evaluating where agents fit in the development lifecycle
+4. **Specification Writing** -- ADRs and RFCs that agents can consume and implement
+
+## Etude Sequence
+
+### Foundation (PSA-001 to PSA-003)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| PSA-001 | Agent-Friendly System Design | Architecture for Agents | System with implicit knowledge agents can't discover (3) | Architecture |
+| PSA-002 | The Specification as Contract | Specification Writing | ADRs/RFCs as agent-consumable implementation guides (2) | Markdown + Code |
+| PSA-003 | Modular Boundaries | Architecture for Agents | Module boundaries for agent-sized work units (3) | Go / TypeScript |
+
+**PSA-001**: A system with tribal knowledge embedded in code: implicit ordering
+dependencies, undocumented invariants, conventions known only through
+institutional memory. An agent working in this system introduces subtle bugs
+because it can't discover what isn't written. The contrast: explicit
+architecture with documented invariants, clear module boundaries, and
+discoverable conventions. **Axiom: Architecture that relies on tribal knowledge
+is architecture that agents will violate.**
+
+**PSA-002**: An RFC describes a new feature in human-oriented prose. An agent
+implementing it misinterprets ambiguities that a human reader would resolve
+through context. The contrast: the same RFC structured with formal interface
+contracts, explicit constraints, and concrete examples that both humans and
+agents can implement against. **Axiom: The best specification is a contract
+that constrains interpretation, not a narrative that invites it.**
+
+**PSA-003**: A monolithic module where every change requires understanding 5,000
+lines of context. Agents struggle because the context window can't hold the full
+picture. The contrast: well-bounded modules with clear interfaces, where each
+module fits comfortably in an agent's working context. **Axiom: Module boundaries
+should fit in an agent's context window and a human's working memory.**
+
+### Fluency (PSA-004 to PSA-007)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| PSA-004 | The Evolutionary Architecture | Architecture for Agents | Designing for future agent capabilities (2) | Architecture |
+| PSA-005 | Documentation as Code | Context Engineering | Self-documenting architecture for agents and humans (3) | Any |
+| PSA-006 | The Platform Decision | Delegation Judgment | Build-with-agent vs. buy vs. build-yourself (2) | Analysis |
+| PSA-007 | Observability Design | Feedback Loop Design | Monitoring agent-generated system behavior (2) | Go / TypeScript |
+
+### Application (PSA-008 to PSA-010)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| PSA-008 | The Data Architecture | Architecture for Agents | Schema design agents can reason about (3) | SQL / Any |
+| PSA-009 | Compliance and Governance | Output Evaluation | Agent output meeting regulatory requirements (2) | Process + Code |
+| PSA-010 | The Migration Strategy | Task Decomposition | Large-scale migration planned for agent execution (2) | Architecture |
+
+### Capstone (PSA-011)
+
+| # | Title | Competency | Stack |
+|---|-------|-----------|-------|
+| PSA-011 | System Redesign | All | Architecture + Code |
+
+Redesign an existing system with agent collaboration explicitly considered:
+module boundaries that fit agent context windows, documented invariants, ADRs
+structured as implementation contracts, and observability for agent-generated
+code behavior.
+
+## Recommended Cross-Training
+
+Complete STE-006 (Agent-Friendly Architecture) and PSE-001 (Architecture Review)
+before starting this path.

--- a/paths/principal-software-engineer.md
+++ b/paths/principal-software-engineer.md
@@ -1,0 +1,88 @@
+# Path: Principal Software Engineer
+
+## Profile
+
+**Experience**: 12+ years. Sets technical direction across multiple teams.
+Evaluates architectural trade-offs. Responsible for long-term code health and
+engineering culture.
+
+**Daily Work**: Architecture reviews, technology strategy, engineering standards,
+technical debt management at org scale, mentoring senior engineers, cross-team
+coordination, evaluating new technologies.
+
+**Unique Challenge**: Must make decisions about agent adoption that affect entire
+organizations, with limited historical precedent. Must balance productivity gains
+against maintainability, skill development, and long-term codebase health.
+
+**Anti-goal**: A principal who either blocks agent adoption ("too risky") or
+mandates it without adapting engineering practices, leading to unmaintainable
+AI-generated code at scale.
+
+## Primary Competencies
+
+1. **Architecture for Agents** -- Designing systems for agent maintainability
+2. **Delegation Judgment** -- Evaluating agent ROI across task types at org scale
+3. **Output Evaluation** -- Establishing review standards for agent output
+4. **Context Engineering** -- Writing guidelines that work across teams
+
+## Etude Sequence
+
+### Foundation (PSE-001 to PSE-003)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| PSE-001 | The Architecture Review | Architecture for Agents | Reviewing agent-proposed architecture uncritically (3) | Go / TypeScript |
+| PSE-002 | Technical Debt Triage | Output Evaluation | Agent code that works but accumulates debt (3) | Go |
+| PSE-003 | The Standards Document | Context Engineering | Guidelines that are too vague or too rigid (3) | Markdown |
+
+**PSE-001**: An agent proposes a system architecture for a new service. It's
+reasonable on the surface but violates an undocumented organizational constraint
+(shared database access pattern, existing service boundaries, compliance
+requirement). The trap is accepting the architecture because it looks sound in
+isolation. **Axiom: Agents architect in a vacuum -- your value is the context
+they cannot see.**
+
+**PSE-002**: Agent-generated code across a codebase over 3 months. Each PR looked
+fine individually. The aggregated result: inconsistent patterns, duplicated
+utilities, abstractions that serve no purpose. The trap is reviewing agent PRs
+at the PR level without tracking aggregate patterns. **Axiom: Agent-generated
+technical debt is invisible at the PR level -- review the forest, not just the
+trees.**
+
+**PSE-003**: Writing an AGENTS.md / CLAUDE.md for the entire org. Too vague ("write
+clean code") and agents ignore it. Too rigid (500 lines of rules) and agents get
+confused by contradictions. The contrast: focused, specific, tested guidelines
+that evolve based on observed agent behavior. **Axiom: Agent guidelines are code
+-- they need testing, iteration, and maintenance.**
+
+### Fluency (PSE-004 to PSE-007)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| PSE-004 | Measuring Agent ROI | Delegation Judgment | Lines-of-code metrics instead of outcomes (3) | Analysis |
+| PSE-005 | The Legacy System | Architecture for Agents | Agent vs. undocumented legacy code (3) | Python / Java |
+| PSE-006 | Design Review Protocol | Output Evaluation | Review standards for agent output (2) | Process |
+| PSE-007 | Prototype vs. Production | Delegation Judgment | Agent prototype mistaken for production-ready (4) | Any |
+
+### Application (PSE-008 to PSE-010)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| PSE-008 | Cross-Team Consistency | Context Engineering | Incompatible agent patterns across teams (2) | Process |
+| PSE-009 | The Skill Preservation | Delegation Judgment | Team skills atrophying from over-reliance (3) | Process |
+| PSE-010 | Security Surface Review | Output Evaluation | Agent-introduced vulnerabilities (3) | Any |
+
+### Capstone (PSE-011)
+
+| # | Title | Competency | Stack |
+|---|-------|-----------|-------|
+| PSE-011 | Org-Wide Practice | All | Process + Code |
+
+Establish agent collaboration practices for a multi-team engineering org:
+guidelines document, review protocol, measurement framework, and training
+recommendations. Produce both the practice documentation and a reference
+implementation.
+
+## Recommended Cross-Training
+
+Complete STE-006 (Agent-Friendly Architecture) before starting this path.

--- a/paths/staff-data-management-engineer.md
+++ b/paths/staff-data-management-engineer.md
@@ -1,0 +1,135 @@
+# Path: Staff Data Management Engineer
+
+## Profile
+
+**Experience**: 8+ years in data engineering, database administration, or data
+platform work. Responsible for schemas, pipelines, data quality, and governance.
+
+**Daily Work**: Schema design and migration, ETL/ELT pipeline development, data
+quality validation, query optimization, data catalog maintenance, data governance
+and compliance (PII handling, retention policies), CDC implementation, data
+warehouse/lakehouse management.
+
+**Unique Challenge**: Data correctness is harder to verify than code correctness.
+A function that compiles and passes tests might still silently corrupt data. SQL
+that returns results might return *wrong* results. A migration that runs
+successfully might lose data. Agent-generated data code requires domain-specific
+review that goes beyond syntax checking and unit tests.
+
+**Anti-goal**: A data engineer who trusts agent-generated SQL because "it
+returned rows" or agent-generated migrations because "they applied without
+errors." Also: one who refuses to use agents for data work because "the risk
+is too high," missing significant productivity gains on well-scoped tasks.
+
+## Primary Competencies
+
+1. **Output Evaluation** -- Data-specific review (correctness, not just syntax)
+2. **Specification Writing** -- Precise data contracts and pipeline specs
+3. **Feedback Loop Design** -- Data quality gates and validation checkpoints
+4. **Context Engineering** -- Providing schema and lineage context to agents
+
+## Etude Sequence
+
+### Foundation (DME-001 to DME-003)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| DME-001 | The Schema Design | Specification Writing | Agent schema missing domain constraints (4) | SQL / PostgreSQL |
+| DME-002 | Migration Safety | Output Evaluation | Agent migration that loses data silently (5) | SQL / Migration tool |
+| DME-003 | The Query Review | Output Evaluation | Agent SQL returning results but subtly wrong (4) | SQL |
+
+**DME-001**: The learner asks an agent to design a schema for a business domain.
+The agent produces a normalized, syntactically correct schema -- but misses
+domain constraints: a `status` field that should be an enum, a `price` field
+that allows negative values, a missing uniqueness constraint on a natural key,
+no `NOT NULL` on a required field. The trap is reviewing for structure rather
+than domain semantics. The contrast: a specification that includes domain
+constraints, valid value ranges, and business rules before the agent designs
+the schema. **Axiom: A schema that satisfies normal forms but ignores domain
+constraints is a schema that will corrupt data.**
+
+**DME-002**: A database migration to add a column and backfill data. The agent
+writes a migration that runs without error -- but the backfill logic has a subtle
+WHERE clause that excludes 2% of rows. Data is silently lost. The trap is
+verifying that the migration applies cleanly without verifying the data
+transformation is correct. The contrast: writing data assertions (row counts,
+value distributions, before/after comparisons) as part of the migration.
+**Axiom: A migration that applies without error is not a migration that's
+correct -- verify the data, not just the DDL.**
+
+**DME-003**: A complex analytical query. The agent writes SQL that returns a
+reasonable-looking result set. But it has a subtle join condition that produces
+a partial cross-product for one category, inflating numbers by 15%. The trap is
+checking that the query runs and returns "reasonable" numbers. The contrast:
+verifying against known test data with predetermined expected results. **Axiom:
+SQL that returns results and SQL that returns correct results are different
+things -- test data with known answers is your safety net.**
+
+### Fluency (DME-004 to DME-007)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| DME-004 | Pipeline Specification | Specification Writing | Vague ETL requirements → fragile pipelines (3) | Python / dbt |
+| DME-005 | Data Quality Gates | Feedback Loop Design | Pipelines without validation checkpoints (3) | Python / Great Expectations |
+| DME-006 | The Context Problem | Context Engineering | Agent unaware of data lineage and dependencies (3) | SQL / dbt |
+| DME-007 | Idempotency and Recovery | Recovery Patterns | Agent pipelines that can't safely re-run (4) | Python / SQL |
+
+**DME-004**: The learner describes an ETL pipeline in informal terms ("load
+customer data from the API, clean it up, put it in the warehouse"). The agent
+builds a pipeline that works for the current data shape but breaks on nulls,
+encoding changes, API pagination, and rate limits. The contrast: a structured
+pipeline spec covering source schema, expected data volumes, error handling
+strategy, idempotency requirements, and SLA. **Axiom: "Clean it up" is not a
+specification -- every transformation must have defined input, output, and
+failure behavior.**
+
+**DME-007**: An agent-built pipeline processes data successfully on first run.
+A failure occurs mid-pipeline on the second run. Restarting the pipeline
+duplicates data because it lacks idempotency guarantees. **Axiom: An agent
+builds for the happy path unless you specify the unhappy paths -- data pipelines
+must handle failure recovery by design.**
+
+### Application (DME-008 to DME-010)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| DME-008 | Performance at Scale | Output Evaluation | Agent queries that work on dev, fail at prod scale (3) | SQL |
+| DME-009 | The Access Pattern | Architecture for Agents | Data APIs agents can reason about (2) | SQL / API |
+| DME-010 | Data Governance | Specification Writing | Agent output respecting PII and retention policies (3) | SQL / Policy |
+
+**DME-008**: Agent-written SQL performs well against a dev database with 10K
+rows. In production with 10M rows, the same query takes 45 minutes because it
+triggers a sequential scan instead of using an index. The trap is accepting
+performance based on dev testing. The contrast: EXPLAIN ANALYZE on realistic
+data volumes, with index analysis as part of agent output review. **Axiom:
+Query performance is a property of data volume, not query syntax -- test at
+scale or specify scale constraints.**
+
+### Capstone (DME-011)
+
+| # | Title | Competency | Stack |
+|---|-------|-----------|-------|
+| DME-011 | Data Platform | All | SQL + Python + dbt |
+
+End-to-end data platform feature: schema design from specification, migration
+with data assertions, ETL pipeline with quality gates, analytical queries with
+verified correctness, and documentation of data lineage. Requires agent
+collaboration at every stage with appropriate review discipline for each.
+
+## Prerequisites
+
+```
+DME-000 (Setup)
+    └── DME-001 (Specification Writing)
+    └── DME-002 (Output Evaluation)
+    └── DME-003 (Output Evaluation)
+            └── DME-004 through DME-007 (Fluency)
+                    └── DME-008 through DME-010 (Application)
+                            └── DME-011 (Capstone)
+```
+
+## Recommended Cross-Training
+
+Complete ASE-003 (The Test First) from the Associate path -- the principle of
+testing before implementation is foundational for data work, where "tests" means
+data assertions and known-answer verification.

--- a/paths/staff-devops-engineer.md
+++ b/paths/staff-devops-engineer.md
@@ -1,0 +1,113 @@
+# Path: Staff DevOps / CI/CD Engineer
+
+## Profile
+
+**Experience**: 8+ years in infrastructure, deployment, and operational systems.
+Responsible for the pipelines that all code -- including agent-generated code --
+flows through.
+
+**Daily Work**: CI/CD pipeline design and maintenance, infrastructure as code
+(Terraform, Pulumi, CloudFormation), container orchestration, deployment
+automation, observability (monitoring, alerting, logging), incident response,
+cloud cost management, security hardening.
+
+**Unique Challenge**: Infrastructure mistakes can be catastrophic and difficult
+to reverse. A misconfigured security group, an overly broad IAM role, or a
+migration that corrupts production data cannot be easily rolled back. Agent-
+generated IaC requires the highest level of review discipline. Additionally,
+the DevOps engineer builds the feedback loops that make agents effective for
+everyone else on the team.
+
+**Anti-goal**: A DevOps engineer who either refuses to use agents for
+infrastructure ("too dangerous") or who trusts agent-generated Terraform without
+thorough security review. Also: building CI/CD that doesn't provide actionable
+feedback to agents.
+
+## Primary Competencies
+
+1. **Feedback Loop Design** -- Building CI/CD that serves both humans and agents
+2. **Output Evaluation** -- Security-focused review of agent-generated IaC
+3. **Context Engineering** -- Providing infrastructure context to agents
+4. **Architecture for Agents** -- Platform engineering for agent-augmented teams
+
+## Etude Sequence
+
+### Foundation (DOE-001 to DOE-003)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| DOE-001 | The CI Feedback Loop | Feedback Loop Design | CI that reports pass/fail without actionable detail (4) | GitHub Actions / YAML |
+| DOE-002 | IaC with Agents | Output Evaluation | Agent Terraform with security misconfigs (4) | Terraform |
+| DOE-003 | Pipeline as Agent Guardrail | Feedback Loop Design | CI stages that catch agent mistakes (3) | GitHub Actions |
+
+**DOE-001**: A CI pipeline that reports "build failed" or "tests passed" with
+no structured output. An agent iterating against this pipeline makes blind
+guesses about what's wrong. The contrast: CI that provides structured, parseable
+error output, lint results, and specific failure locations that agents can act
+on directly. **Axiom: CI output designed for humans to read is CI output agents
+can't use -- design for both audiences.**
+
+**DOE-002**: The learner asks an agent to write Terraform for a new service.
+The agent produces working Terraform that applies cleanly -- but with overly
+permissive security groups, wildcard IAM policies, and public S3 buckets. The
+trap is running `terraform plan` and seeing "3 to add, 0 to change, 0 to
+destroy" and assuming it's correct. The contrast: security-focused review
+checklist + automated policy scanning (OPA, Checkov, tfsec). **Axiom: `terraform
+plan` tells you what will change, not whether it should change -- agent-generated
+IaC requires security review, not just syntax validation.**
+
+**DOE-003**: Designing CI pipeline stages specifically to catch categories of
+agent mistakes: dependency verification (are all packages real?), security
+scanning, integration tests, and deployment canary checks. **Axiom: Every
+category of agent mistake you've seen is a CI stage you should build.**
+
+### Fluency (DOE-004 to DOE-007)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| DOE-004 | The Dockerfile | Context Engineering | Agent building images without constraint context (3) | Docker |
+| DOE-005 | Security Scanning | Output Evaluation | Hallucinated dependencies and supply-chain risk (4) | Any |
+| DOE-006 | The Deployment Strategy | Task Decomposition | Agent-assisted rollout with incremental verification (2) | Kubernetes / IaC |
+| DOE-007 | Monitoring and Alerting | Feedback Loop Design | Agent monitoring that misses critical signals (3) | Prometheus / Grafana |
+
+**DOE-005**: The agent suggests npm packages or Python libraries that don't
+exist (hallucinated packages). Up to 30% of agent-suggested packages are
+hallucinated, creating supply-chain attack vectors. The contrast: automated
+dependency verification in CI. **Axiom: Verify every dependency the agent
+suggests exists before it enters your supply chain.**
+
+### Application (DOE-008 to DOE-010)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| DOE-008 | The Incident Response | Recovery Patterns | Using agents during incidents -- speed vs. risk (3) | Any |
+| DOE-009 | Platform Engineering | Architecture for Agents | Internal platforms agents can operate (2) | Any |
+| DOE-010 | Cost and Resource Management | Delegation Judgment | Agent-provisioned resources without cost awareness (3) | Cloud / IaC |
+
+### Capstone (DOE-011)
+
+| # | Title | Competency | Stack |
+|---|-------|-----------|-------|
+| DOE-011 | Pipeline Overhaul | All | CI/CD + IaC |
+
+End-to-end CI/CD redesign for an agent-augmented team: structured output for
+agent consumption, security scanning stages, dependency verification, deployment
+canaries, and cost guardrails. The pipeline must serve both human developers and
+AI agents effectively.
+
+## Prerequisites
+
+```
+DOE-000 (Setup)
+    └── DOE-001 (Feedback Loop Design)
+    └── DOE-002 (Output Evaluation)
+    └── DOE-003 (Feedback Loop Design)
+            └── DOE-004 through DOE-007 (Fluency)
+                    └── DOE-008 through DOE-010 (Application)
+                            └── DOE-011 (Capstone)
+```
+
+## Recommended Cross-Training
+
+Complete STE-009 (The Feedback Machine) from the Staff SE path -- it approaches
+CI design from the application developer's perspective.

--- a/paths/staff-software-engineer.md
+++ b/paths/staff-software-engineer.md
@@ -1,0 +1,137 @@
+# Path: Staff Software Engineer
+
+## Profile
+
+**Experience**: 8+ years. Deep technical skills with leadership responsibilities.
+Sets technical direction for a team. Years of solo-coding muscle memory.
+
+**Daily Work**: API design, cross-service architecture, code review, mentoring,
+build-vs-buy decisions, technical debt management, incident response leadership.
+
+**Unique Challenge**: Their expertise makes them faster at writing code than
+reviewing agent output, creating resistance. The METR study found experienced
+developers initially took 19% longer with agents -- this path addresses why and
+how to overcome it.
+
+**Anti-goal**: A staff engineer who dismisses agents because "I can do it faster
+myself," or one who adopts agents without adapting their workflow, gaining
+neither the speed benefits nor maintaining their review standards.
+
+## Primary Competencies
+
+1. **Context Engineering** -- Mastering persistent context and targeted information
+2. **Parallel Orchestration** -- Running multiple agent workflows effectively
+3. **Delegation Judgment** -- Matching tasks to agent strengths at scale
+4. **Architecture for Agents** -- Designing systems agents can work in
+
+## Etude Sequence
+
+### Foundation (STE-001 to STE-003)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| STE-001 | The CLAUDE.md | Context Engineering | No persistent context; repeating corrections (5) | Go |
+| STE-002 | Spec-Driven Development | Specification Writing | Jumping straight to code without a spec (4) | Go |
+| STE-003 | The Delegation Matrix | Delegation Judgment | Delegating design; keeping typing (4) | Go |
+
+**STE-001: The CLAUDE.md**
+The learner works in a codebase across multiple sessions. In each session, the
+agent makes the same mistakes: wrong test runner invocation, non-standard error
+handling, ignoring the project's logging conventions. The learner corrects these
+every time. The contrast: creating a CLAUDE.md that captures conventions,
+commands, and constraints. Subsequent sessions produce code that fits the project
+from the first prompt. **Axiom: Every correction you repeat is a CLAUDE.md entry
+you haven't written.**
+
+**STE-002: Spec-Driven Development**
+A cross-service feature requiring API changes, database migration, and frontend
+updates. The learner's instinct (as an experienced engineer) is to start coding
+immediately -- they know what to build. The agent produces code that individually
+works for each piece but doesn't integrate (mismatched field names, inconsistent
+error handling, different date formats). The contrast: a spec document that
+defines the contract first, then implementation against the spec. **Axiom: The
+spec isn't overhead -- it's the interface between your intent and the agent's
+execution.**
+
+**STE-003: The Delegation Matrix**
+A day's work includes a complex algorithm, three API endpoints, a migration
+script, and test coverage improvement. The learner's instinct is to delegate the
+"boring" parts (tests, migration) and keep the "interesting" parts (algorithm).
+The contrast reveals that the algorithm is poorly suited to delegation (hard to
+specify, hard to verify) while the endpoints are ideal (well-defined, easily
+tested). **Axiom: Delegate what's easily verified, not what's boring.**
+
+### Fluency (STE-004 to STE-007)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| STE-004 | Context Window Economics | Context Engineering | Overloading context; signal drowned by noise (3) | Go |
+| STE-005 | The Parallel Sprint | Parallel Orchestration | 5 agents on interdependent tasks (3) | Go |
+| STE-006 | Agent-Friendly Architecture | Architecture for Agents | Clever abstractions confusing agents (3) | Go |
+| STE-007 | The Review Protocol | Output Evaluation | Reviewing AI output with AI (echo chamber) (3) | Go |
+
+**STE-004**: Learner provides the agent with 50 files of context for a change in
+one module. Agent output quality degrades because relevant signals are diluted.
+The contrast: targeted context (only the files the agent needs + interface
+contracts) produces markedly better output. **Axiom: The agent's context window
+is not a database -- every token competes for attention.**
+
+**STE-005**: Learner launches 5 agents on different parts of a feature. Two
+agents make conflicting assumptions about a shared interface. Merging produces
+integration failures. The contrast: independent tasks in parallel, dependent
+tasks sequentially, shared contracts defined upfront. **Axiom: Parallelize
+independent work; serialize shared interfaces.**
+
+**STE-006**: A codebase with metaprogramming, decorator patterns, and DRY
+abstractions. The agent consistently misuses the abstractions or duplicates
+their functionality. The contrast: a simpler, more explicit architecture that
+the agent navigates easily. **Axiom: Code that impresses humans can confuse
+agents -- optimize for both audiences.**
+
+**STE-007**: Learner uses a second AI to review the first AI's output. The
+reviewer misses the same class of errors the generator made. The contrast:
+human review focused on the specific risks of agent-generated code (hallucinated
+APIs, subtle incorrectness, missing edge cases) with automated verification.
+**Axiom: AI cannot reliably catch its own class of errors -- human review and
+automated verification serve different purposes.**
+
+### Application (STE-008 to STE-014)
+
+| # | Title | Competency | Trap (Severity) | Stack |
+|---|-------|-----------|------------------|-------|
+| STE-008 | Recovery and Restart | Recovery Patterns | Sunk-cost on a failing thread (4) | Go |
+| STE-009 | The Feedback Machine | Feedback Loop Design | CI as agent iteration loop (2) | Go |
+| STE-010 | Session Continuity | Session Management | Multi-day feature across sessions (3) | Go |
+| STE-011 | The Migration | Task Decomposition | Large codebase migration with agents (2) | Go |
+| STE-012 | Cross-Cutting Concerns | Context Engineering | Agent unaware of system constraints (3) | Go |
+| STE-013 | The Performance Review | Output Evaluation | Evaluating non-functional quality (2) | Go |
+| STE-014 | Team Patterns | Delegation Judgment | Establishing agent practices for a team (2) | Go |
+
+### Capstone (STE-015)
+
+| # | Title | Competency | Stack |
+|---|-------|-----------|-------|
+| STE-015 | System Feature | All | Go |
+
+End-to-end system feature across multiple services, requiring spec-driven
+development, context engineering, delegation decisions, and team-level review
+practices. The capstone requires both working code and a documented workflow
+that could be shared with a team.
+
+## Prerequisites
+
+```
+STE-000 (Setup)
+    └── STE-001 (Context Engineering)
+    └── STE-002 (Specification Writing)
+    └── STE-003 (Delegation Judgment)
+            └── STE-004 through STE-007 (Fluency)
+                    └── STE-008 through STE-014 (Application)
+                            └── STE-015 (Capstone)
+```
+
+## Recommended Cross-Training
+
+Complete ASE-001 through ASE-003 from the Associate path before starting. The
+basics still apply, and experienced engineers benefit from the humility check of
+encountering the traps in a low-stakes context.


### PR DESCRIPTION
Establish the complete educational framework for agentic co-developer etudes:

- 4 Claude agents (agent-expert, engineering-practice-expert, curriculum-designer,
  etude-writer) mirroring cpptudes' multi-agent authoring pipeline
- 4 matching skills for slash-command invocation
- 6 role-specific learning paths (Associate SE, Staff SE, Principal SE,
  Principal Architect, Staff DevOps, Staff Data Eng) with 80 total etudes
- 10 Core Competencies derived from practitioner research across Claude Code,
  Codex, Jules, and Antigravity
- Trap-then-correct pedagogy adapted from cpptudes
- Dual requirement framework (Requirement A: agent skill, Requirement B: real
  engineering)
- Curriculum map, best practices, concept coverage matrix, authoring pipeline
- ASE-000 setup etude as initial example

https://claude.ai/code/session_01AdhHJGoti5PpST9sGjfjMT