### PR TITLE
Add foundation and fluency etudes for STE, PSA, and DOE paths

### DIFF
--- a/cotudes/DOE-002-iac-with-agents/README.md
+++ b/cotudes/DOE-002-iac-with-agents/README.md
@@ -1,0 +1,267 @@
+# DOE-002: IaC with Agents
+
+> **Axiom**: `terraform plan` tells you what will change, not whether it should change -- agent-generated IaC requires security review, not just syntax validation.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff DevOps / CI/CD Engineer |
+| **Number** | DOE-002 |
+| **Primary Competency** | Output Evaluation |
+| **Secondary Competency** | Context Engineering |
+| **Trap Severity** | 4 (Common) |
+| **Prerequisites** | DOE-000 (Environment Setup), DOE-001 |
+| **Duration** | 2-3 sessions |
+| **Stack** | Terraform |
+
+## Overview
+
+You will ask an agent to write Terraform for a new microservice deployment on
+AWS. The agent will produce syntactically valid, `plan`-clean Terraform that
+would expose your infrastructure to the internet. You will then apply
+security-focused review techniques and automated policy scanning to catch what
+`terraform plan` never will.
+
+## Why Your Coding Agent Cares
+
+Agents are excellent at producing Terraform that applies. They know the resource
+schemas, they get the argument names right, and they produce configurations that
+`terraform plan` accepts without complaint. This is precisely what makes them
+dangerous for infrastructure work.
+
+The agent optimizes for the feedback signal you give it. If you run
+`terraform plan` and relay "0 errors," the agent concludes it succeeded. It has
+no signal that `aws_security_group.service` allows ingress from `0.0.0.0/0`, or
+that `aws_iam_role_policy.service` uses `"Action": "*"`, or that
+`aws_s3_bucket.data` has no `block_public_access` configuration. These are not
+errors in Terraform's type system. They are security misconfigurations that
+`plan` is not designed to detect.
+
+The pattern is consistent: agents default to the most permissive configuration
+that works. An agent writing an IAM policy will use `*` for the resource ARN
+because it doesn't know your account structure. It will open security groups
+wide because restricting them requires context (VPC CIDR ranges, peer services)
+that the agent doesn't have. It will skip S3 bucket policies because the
+bucket "works" without them.
+
+The fix is not to avoid agents for IaC. The fix is to give the agent security
+constraints as input context, and to validate its output with tools designed
+for security review -- OPA, Checkov, tfsec -- not just `terraform plan`.
+
+## The Setup
+
+The `starter/` directory contains a partial Terraform configuration for an AWS
+environment:
+
+- `main.tf` -- provider configuration and backend
+- `variables.tf` -- input variables for the service (name, environment, region)
+- `vpc.tf` -- an existing VPC with public and private subnets
+- `outputs.tf` -- empty, awaiting service outputs
+
+The scenario: you need to deploy a new internal API service. It requires:
+
+- An ECS Fargate service running a container image
+- An Application Load Balancer
+- An S3 bucket for the service's data
+- IAM roles for the ECS task
+- Security groups for the ALB and the service
+- CloudWatch log group
+
+```bash
+cd starter/
+terraform init
+terraform validate   # Should pass -- the existing config is valid
+```
+
+**Your assignment in two phases**:
+
+1. Use an agent to write the Terraform for the new service
+2. Review and harden the output using security scanning tools
+
+## Part 1: The Natural Approach
+
+Start your agent. Give it the task:
+
+> "I need Terraform for a new internal API service called `order-processor`.
+> It should run on ECS Fargate behind an ALB, with an S3 bucket for data
+> storage. Use the existing VPC. Write the Terraform resources I need."
+
+Let the agent produce the Terraform. When it's done, run:
+
+```bash
+terraform fmt
+terraform validate
+terraform plan
+```
+
+If `plan` succeeds, review the output. You will likely see something like:
+
+```
+Plan: 12 to add, 0 to change, 0 to destroy.
+```
+
+This looks correct. The agent produced working Terraform. Ship it?
+
+### Checkpoint
+
+Record in your interaction log:
+
+- [ ] Did `terraform validate` pass?
+- [ ] Did `terraform plan` complete without errors?
+- [ ] Review the security group ingress rules. What CIDR ranges are allowed?
+- [ ] Review the IAM role policy. What actions and resources are permitted?
+- [ ] Review the S3 bucket. Is public access blocked? Is encryption enabled?
+- [ ] Review the ALB. Is it internet-facing or internal?
+- [ ] Review the ECS task definition. What capabilities does the container have?
+- [ ] Count the number of security issues you can find manually.
+
+## Part 2: The Effective Approach
+
+Reset to the starter state. This time, take two actions before engaging the
+agent.
+
+**Step 1: Create a security context document.**
+
+Write a file called `INFRA_REQUIREMENTS.md` that specifies your organization's
+infrastructure policies:
+
+```markdown
+## Security Requirements for All Terraform
+
+### IAM
+- No wildcard (*) actions in IAM policies
+- No wildcard (*) resource ARNs -- scope to specific resources
+- Use least-privilege: only the actions the service actually needs
+- All roles must have a permissions boundary attached
+
+### Networking
+- No security group rules with 0.0.0.0/0 ingress (except public ALBs on 443)
+- Internal services use internal ALBs (scheme = "internal")
+- Security groups must reference other security groups, not CIDR ranges,
+  for service-to-service traffic
+- All ALBs must use HTTPS (port 443) with TLS 1.2 minimum
+
+### S3
+- All buckets must have block_public_access enabled (all four settings)
+- All buckets must have server-side encryption (AES-256 or KMS)
+- All buckets must have versioning enabled
+- Access logging must be configured
+
+### ECS
+- Task definitions must not run as root (use non-root user)
+- Read-only root filesystem where possible
+- No added Linux capabilities unless documented
+- Log driver must be awslogs with a dedicated log group
+
+### General
+- All resources must have tags: Environment, Service, ManagedBy
+- Use data sources to reference existing resources, not hardcoded ARNs
+```
+
+**Step 2: Set up automated policy scanning.**
+
+Install at least one of these tools:
+
+```bash
+# Checkov (Python-based, broad coverage)
+pip install checkov
+
+# tfsec (Go-based, Terraform-specific)
+brew install tfsec
+
+# Or use OPA with Terraform (if you already have Rego policies)
+```
+
+**Step 3: Prompt the agent with context.**
+
+Now start a fresh agent session. Include your security context:
+
+> "Read INFRA_REQUIREMENTS.md. Then write Terraform for a new internal API
+> service called `order-processor` on ECS Fargate behind an ALB, with an S3
+> bucket for data storage. Use the existing VPC. Every resource must comply
+> with the security requirements."
+
+After the agent produces Terraform, run the automated scanner:
+
+```bash
+# Checkov
+checkov -d . --framework terraform
+
+# tfsec
+tfsec .
+```
+
+Feed the scanner output back to the agent:
+
+> "Here are the policy scan results. Fix all findings."
+
+Iterate until the scanner passes clean.
+
+### Checkpoint
+
+- [ ] Did the agent produce least-privilege IAM policies on the first attempt?
+- [ ] Are security groups scoped to specific sources (not `0.0.0.0/0`)?
+- [ ] Is the S3 bucket encrypted, versioned, and access-blocked?
+- [ ] Does `checkov` or `tfsec` pass with zero high-severity findings?
+- [ ] Compare the IAM policy from Part 1 to Part 2 -- how many actions were
+      removed?
+- [ ] Compare the security group rules -- how many CIDR ranges were tightened?
+- [ ] Is the ALB internal (not internet-facing)?
+
+## The Principle
+
+`terraform plan` is a change-detection tool, not a security tool. It answers
+"what will Terraform do?" not "should Terraform do this?" When you use
+`plan` as your only validation, you are checking syntax while ignoring
+semantics.
+
+This is not a new problem. Every experienced infrastructure engineer has a
+mental checklist they run when reviewing Terraform PRs: check the IAM policy,
+check the security groups, check the bucket policy. The difference with
+agent-generated IaC is volume and speed. An agent can produce 500 lines of
+Terraform in seconds. Your mental checklist does not scale to that velocity.
+
+Automated policy scanning (Checkov, tfsec, OPA) scales. These tools encode
+your security checklist as code. They catch the same things you catch in PR
+review, but they catch them every time, on every resource, without fatigue.
+
+The combination is powerful: give the agent your security requirements as
+input context (so it gets closer on the first attempt), then validate its
+output with policy scanners (so you catch what it missed). The agent learns
+from the scanner output and fixes issues -- a tight feedback loop between
+the agent and your security policies.
+
+This is the DevOps equivalent of test-driven development. Your policies are
+the tests. The agent writes the implementation. The scanner runs the tests.
+You review what passes.
+
+> **`terraform plan` tells you what will change, not whether it should change -- agent-generated IaC requires security review, not just syntax validation.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Permissiveness audit**: List every security misconfiguration the agent
+   produced in Part 1. Categorize them (IAM, networking, storage, compute).
+   Which category had the most issues?
+2. **Context impact**: How did the security requirements document change the
+   agent's first-pass output? Which requirements did it follow, and which
+   did it still miss?
+3. **Scanner integration**: How many iterations did it take for the agent to
+   satisfy the policy scanner? Could you add these scanners to your actual
+   CI pipeline?
+4. **Your IaC workflow**: How does your team currently review agent-generated
+   Terraform? What would you add after this exercise?
+
+## Going Further
+
+- Write OPA/Rego policies for your organization's specific security
+  requirements. Run them in CI as a `conftest` step against every Terraform
+  PR.
+- Extend the exercise to a multi-account AWS setup. Give the agent context
+  about account boundaries and cross-account IAM roles. Observe how it
+  handles (or mishandles) trust policies.
+- Try the same exercise with Pulumi or CloudFormation. Compare how the agent
+  handles imperative vs. declarative IaC, and whether the same security
+  patterns appear.

--- a/cotudes/DOE-003-pipeline-as-agent-guardrail/README.md
+++ b/cotudes/DOE-003-pipeline-as-agent-guardrail/README.md
@@ -1,0 +1,296 @@
+# DOE-003: Pipeline as Agent Guardrail
+
+> **Axiom**: Every category of agent mistake you've seen is a CI stage you should build.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff DevOps / CI/CD Engineer |
+| **Number** | DOE-003 |
+| **Primary Competency** | Feedback Loop Design |
+| **Secondary Competency** | Architecture for Agents |
+| **Trap Severity** | 3 (Moderate) |
+| **Prerequisites** | DOE-000 (Environment Setup), DOE-001 |
+| **Duration** | 2-3 sessions |
+| **Stack** | GitHub Actions / YAML |
+
+## Overview
+
+You will design CI pipeline stages that function as guardrails against specific
+categories of agent-generated code errors. Starting with a standard
+build-lint-test pipeline, you will extend it with stages that catch hallucinated
+dependencies, insecure configurations, phantom imports, and deployment risks --
+turning the pipeline itself into a safety net for agent-augmented development.
+
+## Why Your Coding Agent Cares
+
+Agents make specific, repeatable categories of mistakes. They hallucinate
+package names that sound plausible but don't exist on npm or PyPI. They import
+modules that exist in their training data but were never added to the project.
+They generate code that passes unit tests but introduces SQL injection or
+hardcoded credentials. They add dependencies with known CVEs because their
+training data predates the disclosure.
+
+A standard CI pipeline -- build, lint, test -- catches some of these by
+accident. A build fails if an import doesn't resolve. A linter might flag
+a security pattern. But "catches by accident" is not a guardrail strategy.
+You need explicit stages designed for the specific failure modes you've
+observed.
+
+The key insight is that agent mistakes are not random. They cluster into
+categories, and each category has a corresponding automated check. Hallucinated
+dependencies can be verified against the registry. Insecure patterns can be
+detected by SAST tools. Phantom imports can be caught by dependency graph
+analysis. You have seen these mistakes before. The question is whether your
+pipeline is designed to catch them, or whether you are relying on human review
+to catch what the pipeline misses.
+
+The pipeline is the one enforcement point that every code change -- human or
+agent-generated -- must pass through. If your guardrails exist only in PR
+review comments or team norms, agent-generated code bypasses them silently.
+If your guardrails exist as CI stages, nothing ships without passing them.
+
+## The Setup
+
+The `starter/` directory contains a Node.js/TypeScript web service with:
+
+- `src/` -- application source code with a REST API
+- `test/` -- unit and integration tests
+- `package.json` -- dependencies including some intentionally suspicious entries
+- `.github/workflows/ci.yml` -- a basic CI pipeline (build, lint, test)
+
+The codebase has been "worked on by an agent" and contains several planted
+issues across the categories you will build guardrails for:
+
+- Two dependencies in `package.json` that do not exist on npm
+- One dependency with a known critical CVE
+- A hardcoded API key in a configuration file
+- An unused import that references a module not in the dependency tree
+- An S3 upload call with a public ACL
+
+```bash
+cd starter/
+npm install    # This will warn about missing packages -- that's intentional
+npm run build  # May or may not succeed depending on the phantom import
+```
+
+**Your assignment in two phases**:
+
+1. Run the existing pipeline and observe what it catches (and what it misses)
+2. Design and implement targeted CI stages for each failure category
+
+## Part 1: The Natural Approach
+
+Run the existing CI pipeline:
+
+```bash
+npm run build
+npm run lint
+npm test
+```
+
+Observe the results. Some of the planted issues will surface. Others will not.
+
+Now start your agent and ask it to review the codebase:
+
+> "Review this codebase for any issues. Check the dependencies, the security
+> posture, and the code quality."
+
+Observe what the agent finds and what it misses. The agent may catch some
+issues but is unlikely to verify whether every dependency actually exists on
+the registry, or to cross-reference dependency versions against CVE databases.
+
+### Checkpoint
+
+Record in your interaction log:
+
+- [ ] Which of the planted issues did the standard CI pipeline catch?
+- [ ] Which issues did the pipeline miss entirely?
+- [ ] Which issues did the agent catch during review?
+- [ ] Which issues did neither the pipeline nor the agent catch?
+- [ ] How long would these undetected issues survive in a real codebase?
+
+## Part 2: The Effective Approach
+
+Design a CI pipeline with dedicated stages for each category of agent mistake.
+Create or modify `.github/workflows/ci.yml` with the following stages:
+
+**Stage 1: Dependency Verification**
+
+Verify that every dependency in `package.json` actually exists on the npm
+registry:
+
+```bash
+#!/bin/bash
+# verify-deps.sh -- Check that all dependencies exist on npm
+set -euo pipefail
+
+jq -r '.dependencies // {} | keys[]' package.json | while read -r pkg; do
+  status=$(curl -s -o /dev/null -w "%{http_code}" "https://registry.npmjs.org/$pkg")
+  if [ "$status" != "200" ]; then
+    echo "::error::Dependency '$pkg' does not exist on npm (HTTP $status)"
+    exit 1
+  fi
+done
+
+echo "All dependencies verified on npm registry."
+```
+
+**Stage 2: Vulnerability Scanning**
+
+Run `npm audit` and parse results into structured, actionable output:
+
+```bash
+npm audit --json | jq '.vulnerabilities | to_entries[] |
+  select(.value.severity == "critical" or .value.severity == "high") |
+  {name: .key, severity: .value.severity, via: .value.via[0].title}'
+```
+
+Fail the pipeline on critical or high-severity findings.
+
+**Stage 3: Secret Detection**
+
+Use a tool like `gitleaks`, `trufflehog`, or a custom regex scanner to detect
+hardcoded secrets:
+
+```bash
+# Install gitleaks
+# Then:
+gitleaks detect --source . --no-git --report-format json --report-path secrets.json
+
+if [ -s secrets.json ] && [ "$(jq length secrets.json)" -gt 0 ]; then
+  echo "::error::Secrets detected in codebase"
+  jq -r '.[] | "::error file=\(.File),line=\(.StartLine)::\(.Description): \(.Match)"' secrets.json
+  exit 1
+fi
+```
+
+**Stage 4: Import/Dependency Graph Validation**
+
+Verify that every import in the source code resolves to either a local file or
+an installed dependency:
+
+```bash
+# Use madge or a custom script to detect broken imports
+npx madge --circular --warning src/
+npx madge --orphans src/
+
+# Or check that tsc --noEmit catches unresolved modules
+npx tsc --noEmit --pretty 2>&1 | grep "Cannot find module"
+```
+
+**Stage 5: Security Pattern Scanning (SAST)**
+
+Run a static analysis security tool to catch insecure code patterns:
+
+```bash
+# Use semgrep with a security ruleset
+npx @semgrep/semgrep --config "p/security-audit" --config "p/secrets" src/
+```
+
+**Pipeline assembly**: Wire these stages into your workflow:
+
+```yaml
+jobs:
+  verify-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/verify-deps.sh
+
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm audit --audit-level=high
+      - run: bash scripts/detect-secrets.sh
+      - run: bash scripts/sast-scan.sh
+
+  build-lint-test:
+    runs-on: ubuntu-latest
+    needs: [verify-deps]
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm run build
+      - run: npm run lint
+      - run: npm test
+
+  gate:
+    runs-on: ubuntu-latest
+    needs: [verify-deps, security-scan, build-lint-test]
+    steps:
+      - run: echo "All guardrail stages passed"
+```
+
+After implementing the pipeline, run each stage locally and confirm that all
+planted issues are now caught.
+
+### Checkpoint
+
+- [ ] Does the dependency verification stage catch the two fake packages?
+- [ ] Does the vulnerability scanner flag the dependency with a known CVE?
+- [ ] Does the secret detection stage find the hardcoded API key?
+- [ ] Does the import validation catch the phantom import?
+- [ ] Does the SAST scan flag the public S3 ACL?
+- [ ] Do all stages produce structured output that an agent could parse and
+      act on?
+- [ ] Is the pipeline fast enough to run on every PR without becoming a
+      bottleneck?
+
+## The Principle
+
+A CI pipeline is a codified list of things you have decided to care about. The
+standard pipeline -- build, lint, test -- codifies: "does it compile, does it
+follow style rules, do the tests pass." These checks predate the era of
+agent-generated code and were designed for the mistakes human developers make.
+
+Agent-generated code introduces new failure categories that the standard
+pipeline was never designed to catch. Hallucinated dependencies don't trigger
+build failures if the import is unused or conditionally loaded. Insecure
+configurations pass lint checks because linters check style, not security.
+Hardcoded secrets pass tests because tests mock external services.
+
+Every time you encounter a new category of agent mistake -- in your own work
+or reported by others -- ask: "Can I detect this automatically?" If yes, it
+becomes a CI stage. If not, it becomes a review checklist item. Over time,
+your pipeline evolves from a generic build-lint-test chain into a
+purpose-built guardrail system that reflects the actual failure modes of your
+development process.
+
+This is not about mistrusting agents. It is about encoding your operational
+knowledge into automated checks, the same way you encode business logic into
+tests. The pipeline is the institutional memory for everything that can go
+wrong.
+
+> **Every category of agent mistake you've seen is a CI stage you should build.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Coverage mapping**: Create a matrix of agent failure categories vs. CI
+   stages. Which categories are now covered? Which still rely on human review?
+2. **False positive rate**: Did any of the new stages produce false positives?
+   How would you tune them for a real production pipeline?
+3. **Performance budget**: What is the total CI runtime after adding these
+   stages? What is your team's tolerance? Which stages can run in parallel?
+4. **Feedback quality**: When a stage fails, does it produce output specific
+   enough for an agent to fix the issue in one pass? If not, how would you
+   improve it?
+5. **Your incident history**: Think of the last three production incidents
+   caused by code that passed CI. Could a new CI stage have caught them?
+
+## Going Further
+
+- Add a deployment canary stage: after deploying to a staging environment,
+  run smoke tests and verify that key metrics (latency, error rate) stay
+  within bounds before promoting to production.
+- Build a "guardrail registry" -- a document or config file that maps each
+  CI stage to the specific failure category it guards against, with links
+  to the incidents or postmortems that motivated adding it.
+- Extend the dependency verification to check package publish dates. A
+  package that was published in the last 24 hours and has zero downloads
+  is a supply-chain attack indicator, not a legitimate dependency.

--- a/cotudes/DOE-004-the-dockerfile/README.md
+++ b/cotudes/DOE-004-the-dockerfile/README.md
@@ -1,0 +1,259 @@
+# DOE-004: The Dockerfile
+
+> **Axiom**: A Dockerfile that builds is not a Dockerfile that ships -- give agents your production constraints, not just your application code.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff DevOps / CI/CD Engineer |
+| **Number** | DOE-004 |
+| **Primary Competency** | Context Engineering |
+| **Secondary Competency** | Output Evaluation |
+| **Trap Severity** | 3 (Moderate) |
+| **Prerequisites** | DOE-001 through DOE-003 |
+| **Duration** | 1-2 sessions |
+| **Stack** | Docker |
+
+## Overview
+
+You will ask an agent to write a Dockerfile for a Node.js service. The agent
+will produce a working image that is 1.2 GB, runs as root, includes build tools
+in the final image, and invalidates the layer cache on every code change. You
+will then provide production constraint context and watch the agent produce a
+120 MB, non-root, multi-stage image with proper layer ordering.
+
+## Why Your Coding Agent Cares
+
+Agents treat Dockerfiles as build scripts. Given "write a Dockerfile for this
+Node.js app," the agent produces something that builds and runs the application.
+Mission accomplished -- from the agent's perspective.
+
+But "builds and runs" is not your acceptance criteria. Your acceptance criteria
+include image size (because you pay for registry storage and transfer, and
+deployment speed is proportional to image size), security posture (because
+container scanning tools will flag root users and unnecessary packages), layer
+caching (because a Dockerfile that invalidates the cache on every `COPY . .`
+turns a 10-second build into a 3-minute build), and base image policy (because
+your organization has approved base images and `node:latest` is not one of
+them).
+
+The agent doesn't know any of this. It has no context about your registry
+costs, your security scanning requirements, your build time SLOs, or your
+approved base image list. Without that context, it defaults to the simplest
+Dockerfile that works: a single-stage build on the full `node` image, running
+as root, copying everything, installing everything.
+
+This is a pure context engineering problem. The agent is capable of writing
+excellent Dockerfiles -- multi-stage builds, non-root users, `.dockerignore`
+files, optimized layer ordering. It just needs to know that you require these
+things. The gap between the bad Dockerfile and the good one is not skill; it
+is context.
+
+## The Setup
+
+The `starter/` directory contains a Node.js/TypeScript API service:
+
+- `src/` -- TypeScript source (~20 files)
+- `package.json` and `package-lock.json`
+- `tsconfig.json`
+- `test/` -- unit tests
+- No Dockerfile, no `.dockerignore`
+
+The service compiles to JavaScript via `tsc` and runs with `node dist/index.js`.
+It has both `dependencies` and `devDependencies` (test frameworks, type
+definitions, build tools).
+
+```bash
+cd starter/
+npm install
+npm run build
+npm start     # Verify it runs
+```
+
+**Your assignment in two phases**:
+
+1. Ask an agent to write a Dockerfile
+2. Provide production constraints and ask again
+
+## Part 1: The Natural Approach
+
+Start your agent and give it the task:
+
+> "Write a Dockerfile for this Node.js service."
+
+Let the agent produce the Dockerfile. Build and run it:
+
+```bash
+docker build -t order-processor:v1 .
+docker images order-processor:v1    # Note the image size
+docker run --rm order-processor:v1
+```
+
+The image will build. The application will run. Everything works.
+
+### Checkpoint
+
+Record in your interaction log:
+
+- [ ] What is the image size? (Record the exact number.)
+- [ ] What base image did the agent choose? Is it `node:latest`, `node:20`,
+      or something else?
+- [ ] Does the Dockerfile use a multi-stage build?
+- [ ] What user does the container run as? (`docker run --rm order-processor:v1 whoami`)
+- [ ] Are `devDependencies` included in the final image?
+- [ ] Are build tools (`tsc`, type definitions) in the final image?
+- [ ] What is the layer ordering? Does changing a source file invalidate the
+      `npm install` layer?
+- [ ] Is there a `.dockerignore` file?
+- [ ] Run a container scan: `docker scout cves order-processor:v1` or
+      `trivy image order-processor:v1`. How many vulnerabilities?
+
+## Part 2: The Effective Approach
+
+Reset the codebase (delete the Dockerfile and `.dockerignore`). This time,
+create a constraint document before engaging the agent.
+
+**Step 1: Write a Dockerfile specification.**
+
+Create `DOCKERFILE_SPEC.md`:
+
+```markdown
+## Dockerfile Requirements
+
+### Base Image
+- Use node:20-alpine for both build and runtime stages
+- If a build stage needs compilation tools, use node:20-alpine with
+  explicit apk add for only what's needed, and do not carry those
+  into the runtime stage
+
+### Multi-Stage Build
+- Stage 1 (build): install ALL dependencies, compile TypeScript
+- Stage 2 (production): copy only compiled output and production
+  dependencies
+- devDependencies must NOT be in the final image
+
+### Security
+- Final stage must run as a non-root user (create and switch to it)
+- No secrets or credentials in the image
+- Read-only root filesystem compatible (no writes to / at runtime)
+
+### Layer Optimization
+- Copy package.json and package-lock.json BEFORE copying source code
+- Run npm ci (not npm install) for deterministic builds
+- Source code copy should be the last layer that changes frequently
+- Use .dockerignore to exclude node_modules, .git, test/, docs/
+
+### Size Budget
+- Final image must be under 200 MB
+- Target: under 150 MB
+
+### Labels and Metadata
+- Include LABEL with maintainer, version, and description
+- Include HEALTHCHECK instruction
+- Expose the correct port
+
+### Build Args
+- Accept NODE_ENV as a build arg (default: production)
+- Accept APP_VERSION as a build arg
+```
+
+**Step 2: Prompt with constraints.**
+
+Start a fresh agent session:
+
+> "Read DOCKERFILE_SPEC.md. Then write a Dockerfile and .dockerignore for
+> this Node.js service. Follow every requirement in the spec."
+
+Build and evaluate:
+
+```bash
+docker build -t order-processor:v2 .
+docker images order-processor:v2
+docker run --rm order-processor:v2 whoami
+docker scout cves order-processor:v2   # or trivy
+```
+
+**Step 3: Test layer caching.**
+
+Change a source file and rebuild:
+
+```bash
+# Touch a source file
+echo "// comment" >> src/index.ts
+
+# Rebuild -- observe which layers are cached
+docker build -t order-processor:v2-modified .
+```
+
+If layer caching is correct, the `npm ci` layer should be cached and only
+the source copy and build layers should re-run.
+
+### Checkpoint
+
+- [ ] What is the image size? Compare to Part 1.
+- [ ] Does the container run as non-root?
+- [ ] Are `devDependencies` excluded from the final image?
+- [ ] How many vulnerability findings compared to Part 1?
+- [ ] Does modifying source code preserve the dependency install cache?
+- [ ] Is the `.dockerignore` file present and correct?
+- [ ] Does the image include a `HEALTHCHECK`?
+- [ ] Is the total build time acceptable? Does caching work on rebuild?
+
+## The Principle
+
+A Dockerfile is a compression of your operational requirements into a build
+recipe. When you write one yourself, you bring years of context: you know your
+base image policy because you fought the battle to standardize it. You know
+to use multi-stage builds because you debugged a production issue caused by
+`gcc` being in a runtime container. You know to run as non-root because your
+security team's scanner will reject anything else.
+
+The agent has none of this context. It has seen thousands of Dockerfiles in its
+training data, and many of them are tutorials that use `node:latest`, run as
+root, and skip multi-stage builds. Without your constraints, the agent produces
+a statistically average Dockerfile -- and the statistical average is not
+production-grade.
+
+Context engineering for Dockerfiles is straightforward: write down what you
+already know. Your base image policy, your size budget, your security
+requirements, your layer caching expectations. These constraints exist in your
+head or in scattered wiki pages. Consolidating them into a machine-readable
+specification gives the agent the same operational context you carry
+instinctively.
+
+The difference between Part 1 and Part 2 is not agent capability. It is the
+information available to the agent. Same model, same code, dramatically
+different output. This is the leverage of context engineering: you convert your
+infrastructure expertise into agent input, and the agent converts it into
+compliant output.
+
+> **A Dockerfile that builds is not a Dockerfile that ships -- give agents your production constraints, not just your application code.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Size delta**: What was the image size difference between Part 1 and Part 2?
+   Calculate the registry storage and transfer cost difference at your
+   deployment scale.
+2. **Vulnerability delta**: How many CVEs were eliminated by switching base
+   images and removing unnecessary packages?
+3. **Cache effectiveness**: How much build time does proper layer ordering save
+   on a typical code change? Multiply by your daily build count.
+4. **Specification reuse**: Could the `DOCKERFILE_SPEC.md` you wrote apply to
+   other services in your organization? What would you generalize?
+5. **Context inventory**: What other operational constraints do you carry in
+   your head that agents don't know about? List three.
+
+## Going Further
+
+- Create a Dockerfile linter configuration (hadolint) that enforces your
+  organizational policies. Run it in CI as part of the guardrail pipeline
+  from DOE-003.
+- Write a base image policy as a reusable context document. Test it against
+  five different service types (Node.js, Python, Go, Java, static site) and
+  refine it based on what the agent gets wrong.
+- Extend the exercise to Docker Compose. Give the agent a multi-service
+  architecture and observe how it handles networking, volume mounts, and
+  dependency ordering between containers.

--- a/cotudes/DOE-005-security-scanning/README.md
+++ b/cotudes/DOE-005-security-scanning/README.md
@@ -1,0 +1,345 @@
+# DOE-005: Security Scanning
+
+> **Axiom**: Verify every dependency the agent suggests exists before it enters your supply chain.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff DevOps / CI/CD Engineer |
+| **Number** | DOE-005 |
+| **Primary Competency** | Output Evaluation |
+| **Secondary Competency** | Feedback Loop Design |
+| **Trap Severity** | 4 (Common) |
+| **Prerequisites** | DOE-001 through DOE-003 |
+| **Duration** | 2-3 sessions |
+| **Stack** | Node.js (npm) / Python (pip) |
+
+## Overview
+
+You will observe an agent suggest dependencies that do not exist on any package
+registry -- hallucinated packages that sound plausible but are fabrications.
+You will then build an automated dependency verification pipeline that catches
+hallucinated, typosquatted, and suspiciously new packages before they enter
+your project's supply chain.
+
+## Why Your Coding Agent Cares
+
+Agents hallucinate package names. This is not a rare edge case. Research has
+shown that a significant percentage of agent-suggested packages -- across npm,
+PyPI, and other registries -- do not exist. The agent produces
+`npm install express-validator-sanitize` or `pip install flask-auth-utils` with
+full confidence, and neither package is real.
+
+This matters more than a build failure. When `npm install` fails because a
+package doesn't exist, you get an error and move on. The real danger is when
+someone registers the hallucinated package name before you try to install it.
+This is not theoretical -- attackers monitor AI-suggested package names and
+register them with malicious payloads. Your agent suggests a fake package, an
+attacker registers it with a postinstall script that exfiltrates environment
+variables, and your CI pipeline installs it and hands over your secrets.
+
+The second category is legitimate packages with known vulnerabilities. An
+agent trained on code from 2023 will suggest package versions that have since
+had critical CVEs disclosed. It does not know about vulnerabilities discovered
+after its training cutoff. A dependency it suggests may have been safe when the
+training data was collected and compromised by the time you install it.
+
+The third category is typosquatting. An agent might suggest `lodash` but its
+output contains `lodash-utils` or `lodashs` -- close enough to look right in
+a quick review, different enough to be a malicious package registered by an
+attacker.
+
+Your supply chain is only as secure as your weakest dependency. Every package
+the agent adds is a link in that chain. Verification is not optional.
+
+## The Setup
+
+The `starter/` directory contains two projects that simulate agent-generated
+dependency additions:
+
+**Project A** (`starter/node-service/`): A Node.js service where an "agent"
+has added dependencies to `package.json`:
+
+- 15 real, legitimate packages
+- 3 hallucinated packages (names that don't exist on npm)
+- 1 package with a known critical CVE
+- 1 typosquatted package (close to a popular package name)
+
+**Project B** (`starter/python-service/`): A Python service where an "agent"
+has added requirements to `requirements.txt`:
+
+- 10 real, legitimate packages
+- 2 hallucinated packages (names that don't exist on PyPI)
+- 1 package with a known vulnerability
+- 1 package published less than 48 hours ago with zero downloads
+
+```bash
+cd starter/node-service/
+cat package.json    # Review the dependency list
+
+cd ../python-service/
+cat requirements.txt    # Review the requirements
+```
+
+Do not run `npm install` or `pip install` yet. That is the point.
+
+**Your assignment in two phases**:
+
+1. Attempt to review the dependency lists manually and with agent help
+2. Build automated verification tooling
+
+## Part 1: The Natural Approach
+
+Review the dependency lists. For each project, try to identify which packages
+are legitimate and which are suspicious.
+
+Start your agent:
+
+> "Review the package.json dependencies for this Node.js service. Are all
+> of these packages legitimate? Flag any that look suspicious."
+
+Then:
+
+> "Review the requirements.txt for this Python service. Are all of these
+> packages legitimate? Flag any that look suspicious."
+
+Observe the agent's responses. It may flag some packages based on name
+patterns, but it cannot verify existence on the registry in real time. It is
+working from training data, which means it may confidently confirm a
+hallucinated package as real (because the name sounds plausible) or flag a
+legitimate package as suspicious (because it hasn't seen it before).
+
+### Checkpoint
+
+Record in your interaction log:
+
+- [ ] How many of the hallucinated packages did you identify manually?
+- [ ] How many did the agent identify?
+- [ ] Did the agent incorrectly confirm any fake packages as legitimate?
+- [ ] Did the agent flag any real packages as suspicious?
+- [ ] How long did the manual review take?
+- [ ] Could you confidently distinguish all real from fake without checking
+      the registry?
+
+## Part 2: The Effective Approach
+
+Build a dependency verification toolkit that can be run locally and in CI.
+
+**Step 1: npm dependency verification script.**
+
+```bash
+#!/bin/bash
+# verify-npm-deps.sh
+set -euo pipefail
+
+FAILED=0
+
+echo "=== Verifying npm dependencies ==="
+
+# Check all dependencies and devDependencies
+for section in dependencies devDependencies; do
+  packages=$(jq -r ".$section // {} | keys[]" package.json 2>/dev/null)
+  for pkg in $packages; do
+    # Check existence on npm registry
+    status=$(curl -s -o /dev/null -w "%{http_code}" \
+      "https://registry.npmjs.org/$pkg")
+    if [ "$status" != "200" ]; then
+      echo "::error::HALLUCINATED: '$pkg' does not exist on npm (HTTP $status)"
+      FAILED=1
+      continue
+    fi
+
+    # Check package metadata for suspicious signals
+    metadata=$(curl -s "https://registry.npmjs.org/$pkg")
+
+    # Check publish date (flag if < 7 days old)
+    created=$(echo "$metadata" | jq -r '.time.created // empty')
+    if [ -n "$created" ]; then
+      created_ts=$(date -d "$created" +%s 2>/dev/null || echo 0)
+      now_ts=$(date +%s)
+      age_days=$(( (now_ts - created_ts) / 86400 ))
+      if [ "$age_days" -lt 7 ]; then
+        echo "::warning::SUSPICIOUS: '$pkg' was created $age_days days ago"
+      fi
+    fi
+
+    # Check weekly downloads (flag if very low)
+    downloads=$(curl -s "https://api.npmjs.org/downloads/point/last-week/$pkg" \
+      | jq -r '.downloads // 0')
+    if [ "$downloads" -lt 100 ]; then
+      echo "::warning::LOW_DOWNLOADS: '$pkg' has $downloads weekly downloads"
+    fi
+
+    echo "OK: $pkg (downloads: $downloads)"
+  done
+done
+
+# Run npm audit for known vulnerabilities
+echo ""
+echo "=== Vulnerability scan ==="
+npm audit --json 2>/dev/null | jq -r '
+  .vulnerabilities // {} | to_entries[] |
+  select(.value.severity == "critical" or .value.severity == "high") |
+  "::error::CVE: \(.key) - severity: \(.value.severity) - \(.value.via[0].title // "unknown")"
+' || true
+
+exit $FAILED
+```
+
+**Step 2: Python dependency verification script.**
+
+```bash
+#!/bin/bash
+# verify-python-deps.sh
+set -euo pipefail
+
+FAILED=0
+
+echo "=== Verifying Python dependencies ==="
+
+# Parse requirements.txt (handle version specifiers)
+while IFS= read -r line; do
+  # Skip comments and empty lines
+  [[ "$line" =~ ^#.*$ || -z "$line" ]] && continue
+
+  # Extract package name (before any version specifier)
+  pkg=$(echo "$line" | sed 's/[>=<!\[].*//; s/\s*$//')
+
+  # Check existence on PyPI
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    "https://pypi.org/pypi/$pkg/json")
+  if [ "$status" != "200" ]; then
+    echo "::error::HALLUCINATED: '$pkg' does not exist on PyPI (HTTP $status)"
+    FAILED=1
+    continue
+  fi
+
+  # Check metadata for suspicious signals
+  metadata=$(curl -s "https://pypi.org/pypi/$pkg/json")
+
+  # Check if project has been yanked or has very few releases
+  releases=$(echo "$metadata" | jq '.releases | length')
+
+  # Check download stats (via pypistats API)
+  recent_downloads=$(curl -s "https://pypistats.org/api/packages/$pkg/recent" \
+    | jq -r '.data.last_week // 0' 2>/dev/null || echo "unknown")
+
+  echo "OK: $pkg (releases: $releases, recent downloads: $recent_downloads)"
+done < requirements.txt
+
+exit $FAILED
+```
+
+**Step 3: Integrate into CI.**
+
+Add these scripts as a CI stage that runs before `npm install` or
+`pip install`:
+
+```yaml
+jobs:
+  verify-supply-chain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify npm dependencies exist
+        working-directory: node-service
+        run: bash ../scripts/verify-npm-deps.sh
+      - name: Verify Python dependencies exist
+        working-directory: python-service
+        run: bash ../scripts/verify-python-deps.sh
+
+  install-and-build:
+    needs: [verify-supply-chain]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm ci
+      - run: npm run build
+```
+
+The critical ordering: verification runs **before** installation. You do not
+install a package to check if it's safe. You check if it's safe before you
+install it.
+
+**Step 4: Run verification against the starter projects.**
+
+```bash
+cd starter/node-service/
+bash ../../scripts/verify-npm-deps.sh
+
+cd ../python-service/
+bash ../../scripts/verify-python-deps.sh
+```
+
+Review the output. Every hallucinated package should be flagged. Every
+suspicious package should be warned about.
+
+### Checkpoint
+
+- [ ] Did the verification catch all hallucinated packages in both projects?
+- [ ] Did it flag the typosquatted package?
+- [ ] Did it flag the suspiciously new package?
+- [ ] Did `npm audit` catch the package with a known CVE?
+- [ ] Does the verification run before any package installation?
+- [ ] Is the output structured enough for an agent to act on?
+      (Can an agent read the output and remove the bad dependencies?)
+- [ ] What is the runtime of the verification? Is it acceptable for CI?
+
+## The Principle
+
+Supply-chain security has always been hard. Developers add dependencies based
+on a README, a recommendation, or a Stack Overflow answer. The difference
+with agent-generated dependencies is that the recommendation comes from a
+source that cannot distinguish real packages from plausible-sounding names
+it generated from patterns in its training data.
+
+When a human developer adds a dependency, they typically visited the npm page,
+read the README, maybe checked the download count. It is an imperfect process,
+but there is at least a human-in-the-loop verification step. When an agent
+adds a dependency, it writes `"express-validator-sanitize": "^2.1.0"` into
+`package.json` with the same confidence it writes `"express": "^4.18.0"`. One
+is real. One is not. The agent does not know the difference.
+
+Automated verification eliminates this class of risk entirely. A script that
+checks the registry before installation is simple to write, fast to run, and
+catches 100% of hallucinated packages. It also catches typosquatting (by
+checking download counts and creation dates) and known vulnerabilities (by
+running audit tools).
+
+This is not about mistrusting agents. It is about recognizing that dependency
+management is a security-critical operation, and any source of dependency
+recommendations -- human, agent, or automated tool -- should be verified
+against the registry of record before installation.
+
+> **Verify every dependency the agent suggests exists before it enters your supply chain.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Detection confidence**: How many hallucinated packages could you identify
+   without registry verification? What was your false-positive rate?
+2. **Agent review quality**: When you asked the agent to review dependencies,
+   did it demonstrate awareness of the hallucination problem? Did it suggest
+   registry verification?
+3. **Attack surface**: For the hallucinated packages in the starter projects,
+   check if anyone has since registered those names. What does this tell you
+   about the attack vector?
+4. **CI integration cost**: What is the wall-clock time of running dependency
+   verification in CI? Is it acceptable? How could you cache or parallelize
+   it?
+5. **Your projects**: Run the verification script against a real project at
+   work. Were there any surprises?
+
+## Going Further
+
+- Extend the verification to check for package name similarity to popular
+  packages (Levenshtein distance). Flag any dependency whose name is within
+  edit distance 2 of a top-1000 npm package.
+- Build a lockfile diff analyzer that runs on PRs: when `package-lock.json`
+  or `requirements.txt` changes, verify only the newly added packages. This
+  is faster than scanning all dependencies on every run.
+- Research and implement Software Bill of Materials (SBOM) generation. Use
+  tools like `syft` or `cyclonedx-npm` to generate an SBOM, then scan it
+  against vulnerability databases. Compare the coverage to `npm audit`.

--- a/cotudes/DOE-011-pipeline-overhaul/README.md
+++ b/cotudes/DOE-011-pipeline-overhaul/README.md
@@ -1,0 +1,254 @@
+# DOE-011: Pipeline Overhaul
+
+> **Axiom**: A pipeline for an agent-augmented team is not a pipeline with extra stages -- it is the encoded contract between every contributor (human or machine) and production.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff DevOps / CI/CD Engineer |
+| **Number** | DOE-011 |
+| **Primary Competency** | All |
+| **Trap Severity** | N/A (Capstone) |
+| **Prerequisites** | DOE-001 through DOE-010 |
+| **Duration** | 5-8 sessions |
+| **Stack** | CI/CD + IaC (GitHub Actions, Terraform) |
+
+## Overview
+
+You will redesign an entire CI/CD pipeline from scratch for a team where both human developers and AI agents commit code, provision infrastructure, and deploy services. The pipeline must produce structured output agents can parse (DOE-001), enforce security policy on agent-generated IaC (DOE-002), catch known categories of agent mistakes via dedicated stages (DOE-003), validate container builds against production constraints (DOE-004), verify every dependency before installation (DOE-005), execute incremental deployment with canary verification (DOE-006), feed monitoring signals back into the pipeline (DOE-007), support safe agent-assisted incident response (DOE-008), expose platform primitives agents can operate autonomously (DOE-009), and enforce cost guardrails on provisioned resources (DOE-010).
+
+This is not ten separate features bolted onto a YAML file. It is one coherent system where each capability reinforces the others.
+
+## The Scenario
+
+**NovaTech** is a mid-stage startup running 14 microservices on AWS. Their current CI/CD is a collection of GitHub Actions workflows that evolved organically over two years:
+
+- A monolithic `ci.yml` per service: checkout, install, build, test, deploy. Each workflow is 200-400 lines of copy-pasted YAML with service-specific drift.
+- Terraform lives in a separate `infra/` repo with a single `terraform apply` step gated by manual approval. No automated policy scanning. No plan output parsing.
+- Deployment is all-or-nothing: push to main triggers a deploy to production. No canaries, no progressive rollout, no automated rollback.
+- Container images are built with whatever Dockerfile the developer wrote. No base image policy, no size budget, no scanning gate.
+- Monitoring exists (Prometheus + Grafana) but is disconnected from the pipeline. Deployments that degrade latency by 40% are discovered hours later by on-call.
+- Dependency management is `npm install` / `pip install` with no verification step. Two supply-chain incidents in the last year (one typosquat, one malicious post-install script).
+- Cost visibility is a monthly AWS bill reviewed by engineering leadership. No resource-level attribution, no provisioning guardrails.
+
+The team has started using AI agents for development. Three engineers use Claude Code daily. Two use Cursor. Agent-generated PRs account for roughly 30% of merged code. Agent-generated Terraform has already caused one incident: an agent created a public S3 bucket that was discovered during a quarterly security audit, not by CI.
+
+The CTO has asked you to redesign the pipeline. The requirements:
+
+1. **One pipeline framework** that all services use (no more copy-paste YAML)
+2. **Agent-friendly output** at every stage so agents can self-correct without human intervention
+3. **Security gates** that catch agent-generated misconfigurations before they reach production
+4. **Supply-chain verification** that eliminates hallucinated and malicious dependencies
+5. **Progressive deployment** with automated canary analysis and rollback
+6. **Cost guardrails** that prevent any single PR from increasing monthly spend by more than a configurable threshold
+7. **Monitoring integration** that feeds production health signals back into deployment decisions
+
+You have the existing workflows, the Terraform repo, and access to the AWS environment. You have 5-8 sessions.
+
+### The Existing State (Starter Materials)
+
+The `starter/` directory contains:
+
+```
+starter/
+  services/
+    order-api/          # Node.js/TypeScript service
+      .github/workflows/ci.yml
+      Dockerfile
+      package.json
+      src/
+      test/
+    user-service/       # Python/FastAPI service
+      .github/workflows/ci.yml
+      Dockerfile
+      requirements.txt
+      src/
+      test/
+    payment-gateway/    # Go service
+      .github/workflows/ci.yml
+      Dockerfile
+      go.mod
+      cmd/
+      internal/
+  infra/
+    terraform/
+      modules/
+        ecs-service/    # Shared ECS module (overly permissive)
+        networking/     # VPC, subnets, security groups
+        storage/        # S3, RDS
+      environments/
+        staging/
+        production/
+      main.tf
+      variables.tf
+  scripts/
+    deploy.sh           # The current deployment script (bash, no rollback)
+  monitoring/
+    dashboards/         # Grafana JSON exports
+    alerts/             # Prometheus alert rules
+```
+
+Every piece of this starter is intentionally flawed in ways that DOE-001 through DOE-010 taught you to recognize. The CI workflows produce unstructured output. The Terraform has wildcard IAM policies. The Dockerfiles run as root. The dependency lists include hallucinated packages. The deployment script has no health checking. The monitoring is disconnected from CI/CD. There are no cost controls.
+
+## Deliverables
+
+### D1: Reusable Workflow Library
+
+A set of composite GitHub Actions workflows that any service can call. Minimum:
+
+- `ci-build.yml` -- Build and compile with structured error output (annotations, JSON summary)
+- `ci-test.yml` -- Test with machine-readable results (JUnit XML or JSON), coverage reporting
+- `ci-security.yml` -- Dependency verification, vulnerability scanning, secret detection, SAST
+- `ci-docker.yml` -- Container build with base image policy enforcement, size budget, scanning
+- `cd-deploy.yml` -- Progressive deployment with canary, health verification, automated rollback
+- `cd-infra.yml` -- Terraform plan/apply with policy scanning (Checkov/tfsec/OPA), cost estimation
+
+Each workflow must produce structured output consumable by both humans (summary annotations, PR comments) and agents (JSON artifacts, parseable error formats).
+
+### D2: Terraform Pipeline
+
+A redesigned infrastructure pipeline that:
+
+- Runs `terraform plan` and parses the output into structured change summaries
+- Executes policy scanning (Checkov, tfsec, or OPA) and fails on high-severity findings
+- Estimates cost impact of infrastructure changes (Infracost or equivalent) and blocks changes exceeding the threshold
+- Generates a human-readable and agent-readable plan summary as a PR comment
+- Requires explicit approval for destructive changes (resource deletion, security group modification)
+- Produces audit-quality logs of what changed, who approved, and what policy checks passed
+
+### D3: Deployment Pipeline
+
+A progressive deployment system that:
+
+- Deploys canary instances (weighted routing or separate target group)
+- Runs smoke tests against the canary
+- Monitors canary health metrics (error rate, latency p99, CPU/memory) for a configurable bake period
+- Automatically promotes or rolls back based on metric thresholds
+- Produces structured deployment events that feed back into monitoring dashboards
+- Supports both human-triggered and agent-triggered deployments with the same safety guarantees
+
+### D4: Cost Guardrails
+
+An automated cost control layer that:
+
+- Estimates the cost impact of Terraform changes before apply
+- Estimates the cost impact of new or resized ECS services
+- Enforces per-PR cost thresholds (configurable per service and per environment)
+- Produces a cost report as a PR comment and a JSON artifact
+- Alerts when cumulative weekly spend exceeds budget with attribution to specific changes
+
+### D5: Pipeline Context Documents
+
+Context files that enable agents to operate the pipeline effectively:
+
+- `CLAUDE.md` (or equivalent) for the pipeline repository itself, documenting how to add stages, modify workflows, and run locally
+- `INFRA_REQUIREMENTS.md` encoding security policies for all Terraform
+- `DOCKERFILE_SPEC.md` encoding container build standards
+- `DEPLOYMENT_RUNBOOK.md` encoding deployment procedures, rollback criteria, and incident escalation
+- Service-level context files that reference the shared pipeline documentation
+
+### D6: Integration Test Suite
+
+End-to-end tests that verify the pipeline itself:
+
+- A test that submits a PR with a hallucinated dependency and confirms the pipeline rejects it
+- A test that submits Terraform with a public S3 bucket and confirms policy scanning catches it
+- A test that deploys a canary that returns 500s and confirms automated rollback triggers
+- A test that submits a change exceeding the cost threshold and confirms the cost gate blocks it
+- A test that verifies structured output format for each stage (parseable by an agent)
+
+## Constraints
+
+These constraints force you to exercise every competency from the path. They are not optional.
+
+### C1: Agent-Authored First Draft
+
+Use an agent to generate the first draft of every workflow, script, and Terraform module. Do not write the initial version yourself. This forces you to practice output evaluation (DOE-002) and context engineering (DOE-004) at scale -- you must provide enough context for the agent to get close, then systematically review and harden the output.
+
+### C2: Structured Output Everywhere
+
+Every pipeline stage must produce output in a format an agent can parse without heuristics. If a stage fails, its output must contain enough structured information for an agent to diagnose and fix the issue in a single pass. Test this by feeding failure output to an agent and measuring fix iterations. Target: one iteration for any single-stage failure. This exercises DOE-001 and DOE-003.
+
+### C3: Security Gate with Zero High-Severity Bypass
+
+No PR may merge with a high or critical severity finding from any security stage. No manual override. The pipeline enforces this unconditionally. The only way to "bypass" a security finding is to fix it or explicitly add it to a documented exception list with a justification and an expiration date. This exercises DOE-002 and DOE-005.
+
+### C4: Cost Estimation on Every Infrastructure Change
+
+Every Terraform change must include a cost estimate. Changes that increase monthly spend by more than $50 (configurable) require explicit approval with a cost justification. This exercises DOE-010.
+
+### C5: Canary Deployment with Automated Rollback
+
+At least one service must deploy via canary with automated rollback based on production metrics. The canary must run for a minimum bake period, and rollback must trigger without human intervention when metrics breach thresholds. This exercises DOE-006 and DOE-007.
+
+### C6: Pipeline Self-Documentation
+
+The pipeline repository must contain context documents sufficient for an agent to modify the pipeline itself. Test: start a new agent session, point it at the pipeline repo, and ask it to add a new CI stage. If the agent cannot do this without asking clarifying questions about pipeline structure, the documentation is insufficient. This exercises DOE-004 and DOE-009.
+
+### C7: Incident Response Integration
+
+The deployment pipeline must support "incident mode" -- a fast-path deployment with reduced (but not eliminated) gates for hotfixes. Document which gates are relaxed and which are never relaxed (security scanning stays; cost estimation is skipped). This exercises DOE-008.
+
+## Evaluation Criteria
+
+### Architecture (30%)
+
+| Criterion | Exceeds | Meets | Below |
+|-----------|---------|-------|-------|
+| Workflow reusability | Composite workflows with parameterized inputs; adding a new service requires <20 lines of YAML | Shared workflows exist; some service-specific customization needed | Copy-pasted workflows with per-service divergence |
+| Stage independence | Stages run in parallel where possible; failures in one stage do not block unrelated stages | Most stages are independent; some unnecessary sequential dependencies | Monolithic pipeline where everything runs sequentially |
+| Terraform pipeline | Plan, policy scan, cost estimate, and apply as separate gated stages with structured output at each | Plan and apply separated; policy scanning present but output not fully structured | Single `terraform apply` step or policy scanning missing |
+| Deployment progressiveness | Canary with metric-based promotion, configurable bake time, automated rollback | Canary exists; rollback is automated but metric thresholds are hardcoded | All-or-nothing deployment or manual rollback only |
+
+### Feedback Quality (25%)
+
+| Criterion | Exceeds | Meets | Below |
+|-----------|---------|-------|-------|
+| Error output structure | Every stage emits JSON artifacts + GitHub annotations; agent fixes issues in 1 iteration consistently | Most stages produce structured output; agent needs 1-2 iterations | Stages produce human-readable logs only; agent needs 3+ iterations |
+| PR comments | Automated PR comments with security findings, cost estimates, test results, and deployment status in structured format | PR comments exist for major stages | No automated PR comments or comments are unstructured prose |
+| Monitoring feedback | Production metrics feed back into deployment decisions automatically | Monitoring dashboards exist; manual verification during deploys | Monitoring is disconnected from CI/CD |
+
+### Security (25%)
+
+| Criterion | Exceeds | Meets | Below |
+|-----------|---------|-------|-------|
+| Dependency verification | Registry existence check + age/download heuristics + vulnerability scan + SBOM generation | Registry existence check + vulnerability scan | `npm audit` only or no verification |
+| IaC policy scanning | OPA/Checkov/tfsec with custom org policies; zero high-severity findings allowed; exception process documented | Standard policy scanner with default rules; high-severity blocks merge | No automated policy scanning |
+| Secret detection | Pre-commit hook + CI stage + entropy-based and pattern-based scanning | CI-stage secret detection with standard tooling | No automated secret detection |
+| Container security | Base image policy + non-root enforcement + size budget + vulnerability scanning | Some container scanning; non-root enforced | No container security gates |
+
+### Operational Maturity (20%)
+
+| Criterion | Exceeds | Meets | Below |
+|-----------|---------|-------|-------|
+| Cost controls | Per-PR cost estimation + budget thresholds + weekly spend attribution + alerting | Cost estimation present; manual review of estimates | No cost visibility in pipeline |
+| Incident fast-path | Documented incident mode with reduced-but-safe gate set; tested with a simulated incident | Incident mode exists but not tested end-to-end | No differentiated incident deployment path |
+| Pipeline self-service | Agent can add a new CI stage or onboard a new service by reading context docs alone | Context docs exist; agent needs minor clarification | No pipeline documentation or docs are stale/incomplete |
+| Rollback capability | Automated metric-based rollback + manual rollback command + rollback audit log | Automated rollback on canary failure | No automated rollback |
+
+## Reflection
+
+This is the final reflection for the DOE path. These questions look back across all ten preceding etudes and this capstone.
+
+Record in your interaction log:
+
+1. **Feedback loop inventory**: Map every pipeline stage you built to the DOE etude that taught the underlying principle. Which etude's lesson was most critical to the final design? Which was hardest to implement in practice?
+
+2. **Agent output evaluation at scale**: In DOE-002 you evaluated a single Terraform module. In this capstone you evaluated agent output across workflows, scripts, IaC, Dockerfiles, and deployment logic. How did your review process change at scale? What did you miss that the pipeline caught? What did you catch that the pipeline missed?
+
+3. **Context engineering ROI**: You wrote multiple context documents (CLAUDE.md, INFRA_REQUIREMENTS.md, DOCKERFILE_SPEC.md, DEPLOYMENT_RUNBOOK.md). For each, estimate the time investment to write it vs. the time saved across all subsequent agent interactions. Which had the highest return?
+
+4. **The constraint that mattered most**: Which of the seven constraints (C1-C7) forced the most significant design improvement? Which felt like overhead that did not pull its weight?
+
+5. **Dual-audience design**: The pipeline serves humans and agents. Where did these audiences' needs conflict? Where did optimizing for one audience unexpectedly benefit the other?
+
+6. **Security posture change**: Compare NovaTech's security posture before and after. List every class of vulnerability that is now caught automatically. List any classes that still require human review. Is the residual risk acceptable?
+
+7. **Cost visibility**: Before this capstone, cost was a monthly surprise. After, cost is estimated per-PR and tracked per-change. How does this change the team's relationship to infrastructure spending? Would the cost guardrails have prevented past incidents?
+
+8. **What you would do differently**: If you started this capstone over, what would you build first? What sequence would you follow? What would you skip or defer?
+
+9. **The axiom test**: State the path's axiom in your own words. Then test it: describe a pipeline design decision you made during this capstone that would have been different without the axiom. If you cannot point to a concrete decision it influenced, the axiom has not landed -- revisit it.
+
+10. **Readiness**: You now have a pipeline that encodes your operational knowledge, serves both humans and agents, and catches the failure modes you have studied across ten etudes. What is the first thing you will change about your actual CI/CD at work on Monday?

--- a/cotudes/PSA-002-the-specification-as-contract/README.md
+++ b/cotudes/PSA-002-the-specification-as-contract/README.md
@@ -1,0 +1,301 @@
+# PSA-002: The Specification as Contract
+
+> **Axiom**: The best specification is a contract that constrains interpretation, not a narrative that invites it.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Principal Software Architect |
+| **Number** | PSA-002 |
+| **Primary Competency** | Specification Writing |
+| **Secondary Competency** | Context Engineering |
+| **Trap Severity** | 2 (Foundation) |
+| **Prerequisites** | PSA-001 |
+| **Duration** | 2-3 sessions |
+| **Stack** | Markdown + Code |
+
+## Overview
+
+You will write an RFC for a rate-limiting feature, first in the way you
+normally write RFCs -- well-reasoned prose aimed at an architecture review
+board. An agent implementing it will misinterpret ambiguities that any
+experienced engineer on your team would resolve through context. Then you will
+restructure the same RFC as a formal contract and watch the agent deliver
+exactly what you specified.
+
+## Why Your Coding Agent Cares
+
+Agents are literal interpreters. When your RFC says "the system should handle
+bursts gracefully," an agent must choose a specific behavior: drop requests?
+queue them? increase the limit temporarily? A human reader on your team knows
+you mean "use a token bucket with burst capacity equal to 2x the sustained
+rate" because they were in the meeting where you discussed it. The agent was
+not in that meeting.
+
+The problem compounds with architectural prose. Phrases like "leverage the
+existing middleware stack," "follow our standard error handling patterns," and
+"integrate with the metrics pipeline" each contain three or four unstated
+decisions. An experienced engineer resolves them through pattern-matching
+against your codebase and organizational context. An agent resolves them by
+making plausible guesses -- and plausible guesses produce plausible bugs.
+
+The failure mode is not obvious wrongness. The agent will produce clean,
+well-structured code that implements a coherent interpretation of your RFC. It
+will pass the tests it writes for itself. In review, you will notice that it
+chose sliding window instead of token bucket, logs errors instead of returning
+429s, and counts by IP instead of by API key. Each choice is defensible. None
+of them is what you meant.
+
+Formal contracts eliminate this class of error. When the RFC specifies the
+interface signature, the constraint boundaries, the error codes, and the
+concrete examples of expected input/output behavior, ambiguity has nowhere to
+hide. The agent becomes an implementer of a spec rather than an interpreter of
+intent. This is not a concession to agent limitations -- it is better
+specification writing, period. Your human reviewers benefit equally.
+
+## The Setup
+
+The `starter/` directory contains **gateway**, a Go HTTP API gateway with
+authentication, routing, and request logging. The system currently has no
+rate limiting.
+
+```bash
+cd starter/
+go build ./...
+go test -race -count=1 ./...
+```
+
+The codebase includes:
+
+- `internal/middleware/` -- middleware chain (auth, logging, CORS)
+- `internal/router/` -- route registration and dispatch
+- `internal/store/` -- Redis-backed session and state storage
+- `internal/metrics/` -- Prometheus metric emission
+- `cmd/gateway/main.go` -- service entrypoint
+
+You also have an RFC document at `docs/rfc-rate-limiting.md`. This is the
+prose-style RFC you will use in Part 1.
+
+**Your assignment**: Implement rate limiting for the gateway based on the RFC.
+
+## Part 1: The Natural Approach
+
+Read the RFC at `docs/rfc-rate-limiting.md`. It describes the rate-limiting
+feature the way a senior architect typically writes for an architecture review:
+
+> **RFC-0042: Rate Limiting for API Gateway**
+>
+> We need to add rate limiting to the gateway to protect downstream services
+> from abuse and ensure fair usage across tenants. The rate limiter should
+> integrate with our existing middleware stack and use Redis for distributed
+> state.
+>
+> Limits should be configurable per tenant and per endpoint. When a client
+> exceeds their limit, the system should return an appropriate error response
+> with retry information. The system should handle bursts gracefully and
+> degrade well under Redis failures.
+>
+> Rate limit headers should follow industry conventions. Metrics should be
+> emitted for rate limit events to feed our existing alerting pipeline.
+> The implementation should be efficient enough to add negligible latency
+> to the request path.
+
+Start a new agent session. Provide the RFC and the codebase. Ask the agent to
+implement rate limiting according to the RFC.
+
+Let the agent work. Review the result.
+
+### Checkpoint
+
+Evaluate the agent's implementation against these questions:
+
+- [ ] What algorithm did the agent choose? (Sliding window? Token bucket?
+  Fixed window? Leaky bucket?)
+- [ ] How does it identify clients? (IP? API key? Tenant ID? Some combination?)
+- [ ] What HTTP status code does it return? What headers?
+- [ ] What happens during a Redis outage -- fail open or fail closed?
+- [ ] How are per-tenant and per-endpoint limits structured in configuration?
+- [ ] What metrics are emitted? What label cardinality?
+- [ ] Where in the middleware chain is it placed?
+
+Count the decisions the agent made that diverge from what you intended. Every
+divergence traces back to an ambiguity in the RFC.
+
+## Part 2: The Effective Approach
+
+Reset the codebase. Replace the prose RFC with a contract-style specification
+at `docs/rfc-rate-limiting.md`:
+
+```markdown
+# RFC-0042: Rate Limiting for API Gateway
+
+## Interface Contract
+
+### Middleware Signature
+
+```go
+func NewRateLimiter(cfg RateLimitConfig, store redis.Client) middleware.Middleware
+```
+
+The rate limiter MUST be inserted in the middleware chain AFTER authentication
+(so tenant ID is available) and BEFORE routing.
+
+### Algorithm
+
+Token bucket. Each (tenant_id, endpoint) pair gets an independent bucket.
+
+- `rate`: sustained requests per second (configurable, default: 100)
+- `burst`: maximum burst size (configurable, default: 200)
+- Refill: continuous (not per-interval)
+
+### Client Identification
+
+Rate limit key: `ratelimit:{tenant_id}:{endpoint_pattern}`
+
+- `tenant_id`: extracted from the authenticated request context
+  (`ctx.Value("tenant_id")`)
+- `endpoint_pattern`: the registered route pattern, not the concrete path
+  (e.g., `/api/v1/users/:id`, not `/api/v1/users/abc123`)
+
+### Response on Limit Exceeded
+
+HTTP 429 Too Many Requests.
+
+```json
+{
+  "error": "rate_limit_exceeded",
+  "retry_after_seconds": 2.5
+}
+```
+
+### Response Headers (all responses)
+
+| Header | Value | Example |
+|--------|-------|---------|
+| `X-RateLimit-Limit` | Bucket capacity (burst) | `200` |
+| `X-RateLimit-Remaining` | Tokens remaining | `147` |
+| `X-RateLimit-Reset` | Unix timestamp when bucket is full | `1700000000` |
+| `Retry-After` | Seconds until a request would succeed (429 only) | `3` |
+
+### Redis Failure Behavior
+
+Fail OPEN. If Redis is unreachable, allow the request and emit a
+`ratelimit_redis_error_total` counter metric. Log at WARN, not ERROR.
+
+### Configuration
+
+```yaml
+rate_limits:
+  default:
+    rate: 100
+    burst: 200
+  tenants:
+    tenant-abc:
+      rate: 500
+      burst: 1000
+      endpoints:
+        "/api/v1/reports": { rate: 10, burst: 20 }
+```
+
+### Metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `ratelimit_requests_total` | counter | `tenant_id`, `endpoint`, `decision={allowed,denied}` |
+| `ratelimit_redis_error_total` | counter | -- |
+| `ratelimit_latency_seconds` | histogram | -- |
+
+Do NOT add `path` as a label (unbounded cardinality). Use `endpoint`
+(the route pattern).
+
+### Example Behavior
+
+Request sequence for tenant "acme", endpoint `/api/v1/users/:id`,
+config `rate=2, burst=5`:
+
+| Time (s) | Request # | Tokens Before | Decision | Tokens After |
+|-----------|-----------|---------------|----------|--------------|
+| 0.0 | 1 | 5 | allowed | 4 |
+| 0.0 | 2 | 4 | allowed | 3 |
+| 0.0 | 3 | 3 | allowed | 2 |
+| 0.0 | 4 | 2 | allowed | 1 |
+| 0.0 | 5 | 1 | allowed | 0 |
+| 0.0 | 6 | 0 | denied | 0 |
+| 0.5 | 7 | 1 | allowed | 0 |
+| 1.0 | 8 | 2 | allowed | 1 |
+```
+
+Start a new agent session with the restructured RFC and the same codebase.
+Give the same high-level instruction: "Implement rate limiting according to
+the RFC."
+
+### Checkpoint
+
+Evaluate the implementation against the same questions from Part 1:
+
+- [ ] Algorithm: token bucket? (Specified explicitly.)
+- [ ] Client identification: tenant_id + endpoint_pattern? (Specified.)
+- [ ] HTTP 429 with the exact JSON body and headers? (Specified.)
+- [ ] Redis failure: fail open with WARN log and counter metric? (Specified.)
+- [ ] Configuration structure matches the YAML example? (Specified.)
+- [ ] Metrics match the table, with no unbounded cardinality? (Specified.)
+- [ ] Middleware position: after auth, before routing? (Specified.)
+
+Count the divergences. Compare to Part 1.
+
+## The Principle
+
+You have been writing RFCs and ADRs for years. Your prose is tight,
+your reasoning is sound, and your architecture review board trusts your
+judgment. The problem is not the quality of your thinking -- it is the
+format of its expression.
+
+Prose-based RFCs are optimized for persuasion: they explain *why* a
+design is correct to a human audience that shares your organizational
+context. Contract-based specifications are optimized for implementation:
+they define *what* must be built in terms that leave no room for
+interpretation.
+
+The gap between "any good engineer would know what I mean" and "the
+specification uniquely determines the implementation" is where agent bugs
+live. It is also where human bugs live -- you just catch them in code
+review because the reviewer shares your context. When the implementer is
+an agent, there is no shared context. There is only the document.
+
+This is not about dumbing down your writing. Contracts are harder to write
+than prose. Every ambiguity you eliminate is a decision you must actually
+make, rather than deferring to the implementer's judgment. That is the
+point. Architecture is the art of making decisions explicit.
+
+> **The best specification is a contract that constrains interpretation, not a narrative that invites it.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Ambiguity count**: How many decisions did the agent make differently in
+   Part 1 vs. Part 2? List each ambiguity the prose RFC left open.
+2. **Specification effort**: How much longer did the contract-style RFC take
+   to write? Was the effort front-loaded (writing the spec) or back-loaded
+   (fixing the implementation)?
+3. **Decision forcing**: Which decisions did writing the contract force you
+   to make that you had been unconsciously deferring?
+4. **Human benefit**: Would the contract-style RFC have improved a human
+   implementer's output? In what ways?
+5. **Spec maintenance**: How would you keep contract-style specifications
+   from drifting as the implementation evolves?
+
+## Going Further
+
+- Take a real RFC or ADR from your organization. Identify every ambiguity
+  an agent would need to resolve. Rewrite the ambiguous sections as formal
+  contracts. Measure: how many of those ambiguities had different engineers
+  on your team interpreting them differently?
+- Write a contract-style specification for a feature, then have an agent
+  implement it without any additional guidance. Track how many clarifying
+  questions the agent asks vs. how many assumptions it makes silently.
+- Build a specification template for your organization that includes
+  mandatory sections: interface signatures, error behavior, configuration
+  schema, concrete examples, and metric definitions. Pilot it with your
+  team for one quarter.

--- a/cotudes/PSA-003-modular-boundaries/README.md
+++ b/cotudes/PSA-003-modular-boundaries/README.md
@@ -1,0 +1,268 @@
+# PSA-003: Modular Boundaries
+
+> **Axiom**: Module boundaries should fit in an agent's context window and a human's working memory.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Principal Software Architect |
+| **Number** | PSA-003 |
+| **Primary Competency** | Architecture for Agents |
+| **Secondary Competency** | Task Decomposition |
+| **Trap Severity** | 3 (Intermediate) |
+| **Prerequisites** | PSA-001, PSA-002 |
+| **Duration** | 3-4 sessions |
+| **Stack** | Go / TypeScript |
+
+## Overview
+
+You will add a feature to a monolithic module where every change requires
+understanding 5,000+ lines of intertwined logic. The agent will produce code
+that is locally coherent but violates cross-cutting concerns it could not fit
+in its context window. Then you will decompose the module into well-bounded
+units and watch the same agent deliver a correct implementation by reasoning
+about one module at a time.
+
+## Why Your Coding Agent Cares
+
+Context windows are large and getting larger. This does not solve the problem.
+An agent that can *hold* 200K tokens of code cannot *reason* about 200K tokens
+of code with the same fidelity it reasons about 2K tokens. Context capacity and
+reasoning fidelity are different things. You experience the same effect: you can
+read a 5,000-line file, but you cannot hold its full dependency graph in your
+head while making a change at line 3,400.
+
+Monolithic modules create a specific failure pattern with agents. The agent
+reads the file, identifies the function it needs to modify, and makes a change
+that is correct in isolation. But the function has implicit coupling to state
+initialized 2,000 lines above, a validation routine 800 lines below, and a
+cache invalidation side effect in a method it never reads because it appeared
+outside the window of code the agent chose to focus on. The resulting bug is
+not a misunderstanding of the function -- it is a misunderstanding of the
+function's entanglement with everything else in the module.
+
+The classic architect response is "that module needs refactoring." Correct.
+But the refactoring criteria have changed. The old heuristic was cohesion and
+coupling. The new heuristic adds a constraint: each module must be
+comprehensible within a single unit of focused attention -- whether that
+attention belongs to a human or an agent. A module that requires scrolling
+through 5,000 lines to understand the impact of a 10-line change is a module
+that both humans and agents will modify incorrectly.
+
+Well-bounded modules with explicit interfaces convert a global reasoning
+problem into a local one. The agent reads the module, reads its interface
+contract, and implements against the contract. It does not need to understand
+the entire system. Neither do you.
+
+## The Setup
+
+The `starter/` directory contains **billingcore**, a billing engine with a
+single dominant module. The system processes subscription billing: plan
+management, usage metering, invoice generation, payment processing, proration
+calculations, and tax computation.
+
+```bash
+cd starter/
+go build ./...
+go test -race -count=1 ./...
+```
+
+The critical file is `internal/billing/engine.go` -- approximately 5,200 lines
+containing:
+
+- Plan and pricing logic (lines ~1-800)
+- Usage metering and aggregation (lines ~800-1,600)
+- Invoice generation with line-item calculations (lines ~1,600-2,800)
+- Proration for mid-cycle upgrades/downgrades (lines ~2,800-3,600)
+- Tax computation with jurisdiction rules (lines ~3,600-4,400)
+- Payment orchestration and retry logic (lines ~4,400-5,200)
+
+The module has extensive internal cross-references: invoice generation calls
+proration helpers, proration calls pricing functions, tax computation reads
+plan metadata, payment retry reads invoice state. These cross-references are
+function calls within the same package, with shared mutable state through a
+`BillingContext` struct threaded through most functions.
+
+Supporting files exist in `internal/billing/` -- types, helpers, test fixtures
+-- but the core logic lives in `engine.go`.
+
+**Your assignment**: Add support for **multi-currency billing**. Tenants can
+now have a `billing_currency` (USD, EUR, GBP). All monetary calculations --
+pricing, usage metering, invoice totals, proration, tax, and payments -- must
+respect the tenant's currency. Exchange rates come from an external service.
+Currency conversion must happen at invoice generation time, not at the
+individual line-item level (to avoid rounding drift).
+
+## Part 1: The Natural Approach
+
+Start a new agent session in the `starter/` directory. Describe the feature:
+
+> "Add multi-currency billing support. Tenants have a billing_currency field
+> (USD, EUR, GBP). All monetary calculations must use the tenant's currency.
+> Exchange rates come from a new ExchangeRateService. Conversion happens at
+> invoice generation time, not per line item. Update pricing, metering,
+> invoicing, proration, tax, and payments to handle multiple currencies."
+
+Let the agent work through `engine.go`. Observe how it approaches the 5,200-
+line file. Watch for:
+
+- How does the agent navigate the file?
+- Does it read the entire file or work on sections?
+- How does it handle cross-cutting concerns that span sections?
+
+Run the tests. Review the implementation.
+
+### Checkpoint
+
+- [ ] Does the currency conversion happen at invoice generation time (not per
+  line item)?
+- [ ] Does proration correctly handle currency -- prorating in the base
+  currency and converting once?
+- [ ] Does the tax computation use the correct currency for jurisdiction
+  lookups?
+- [ ] Are exchange rates fetched once per invoice (not once per calculation)?
+- [ ] Does payment processing pass the correct currency to the payment
+  gateway?
+- [ ] Is the `BillingContext` correctly threaded with currency information
+  through all call paths?
+- [ ] Do the existing tests still exercise meaningful assertions, or did the
+  agent weaken them to make them pass?
+
+Count the cross-cutting bugs. Each one traces to a section of `engine.go`
+the agent could not hold in context while modifying another section.
+
+## Part 2: The Effective Approach
+
+Reset the codebase. Before starting a new session, decompose `engine.go` into
+bounded modules:
+
+```
+internal/billing/
+  plan/
+    plan.go          # Plan and pricing logic
+    plan_test.go
+    interface.go     # PlanService interface
+  metering/
+    metering.go      # Usage metering and aggregation
+    metering_test.go
+    interface.go     # MeteringService interface
+  invoice/
+    invoice.go       # Invoice generation, line-item calculation
+    invoice_test.go
+    interface.go     # InvoiceService interface
+  proration/
+    proration.go     # Mid-cycle proration logic
+    proration_test.go
+    interface.go     # ProrationCalculator interface
+  tax/
+    tax.go           # Tax computation, jurisdiction rules
+    tax_test.go
+    interface.go     # TaxCalculator interface
+  payment/
+    payment.go       # Payment orchestration, retry
+    payment_test.go
+    interface.go     # PaymentProcessor interface
+  currency/
+    currency.go      # Currency types, exchange rate client
+    currency_test.go
+    interface.go     # ExchangeRateService interface
+  engine.go          # Orchestrator: composes services via interfaces
+```
+
+Each module:
+- Is 300-800 lines
+- Depends on other modules through interfaces only
+- Receives its dependencies via constructor injection
+- Owns its own types (no shared `BillingContext` mega-struct)
+
+The `engine.go` orchestrator is now a thin composition layer that wires modules
+together and defines the billing workflow. It passes a `Currency` value and
+an `ExchangeRateSnapshot` (fetched once at invoice generation time) to each
+module that needs it.
+
+Create an `ARCHITECTURE.md` in `internal/billing/` documenting:
+- Module boundaries and responsibilities
+- Interface contracts between modules
+- The currency invariant: conversion happens once, at the orchestration layer
+- Data flow: which module produces what, which module consumes it
+
+Now start a new agent session. Give the same task description. Observe:
+the agent can now reason about one module at a time, implement against
+an interface, and trust that the orchestrator handles cross-cutting concerns.
+
+### Checkpoint
+
+Same questions as Part 1:
+
+- [ ] Currency conversion at invoice generation time?
+- [ ] Proration handles currency correctly?
+- [ ] Tax computation uses correct currency?
+- [ ] Exchange rates fetched once per invoice?
+- [ ] Payment processing with correct currency?
+- [ ] No shared mutable state threading issues?
+- [ ] Tests exercise real assertions?
+
+Compare the defect count. Compare the time the agent spent navigating code
+vs. implementing logic.
+
+## The Principle
+
+Module boundaries have always been about managing complexity. The original
+arguments -- cohesion, coupling, information hiding -- are fundamentally
+arguments about human cognitive limits. A well-designed module is one that a
+single engineer can understand, modify, and verify without holding the entire
+system in their head.
+
+Agents have the same constraint, expressed differently. Instead of working
+memory, they have context windows. Instead of cognitive load, they have
+attention degradation over long contexts. The practical effect is identical: a
+module that requires global understanding to modify locally will be modified
+incorrectly.
+
+The size heuristic is useful: if a module is under 800 lines with a clear
+interface, both a human and an agent can reason about it completely. But size
+alone is insufficient. A 400-line module with implicit dependencies on three
+other modules is worse than an 800-line module that is self-contained. The
+real boundary is the interface contract: what goes in, what comes out, what
+invariants are maintained.
+
+Architects have been saying "decompose that module" for decades. The urgency
+has increased. When agents are the primary authors of code changes, module
+boundaries are not just a quality heuristic -- they are an error boundary. A
+well-bounded module limits the blast radius of an agent's misunderstanding to
+the module itself. A monolith lets a single misunderstanding propagate through
+every function it touches.
+
+> **Module boundaries should fit in an agent's context window and a human's working memory.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Navigation patterns**: How did the agent navigate the 5,200-line file?
+   Did it read top-to-bottom? Jump to specific functions? Miss sections
+   entirely? What does this tell you about how agents manage large contexts?
+2. **Cross-cutting failures**: Which bugs were caused by the agent failing to
+   hold two distant sections of the file in context simultaneously? Would a
+   human reviewer have caught them?
+3. **Decomposition effort**: How long did the module decomposition take? Was
+   the refactoring mechanical or did it require architectural judgment?
+4. **Interface design**: Which interface boundaries were obvious? Which
+   required you to make non-obvious decisions about what belongs where?
+5. **Size threshold**: In your experience, what is the maximum module size
+   (in lines) where agents consistently produce correct implementations?
+
+## Going Further
+
+- Measure the agent's accuracy as a function of module size. Take a well-
+  bounded module and progressively inline its dependencies, creating larger
+  and larger files. At what size does the agent's error rate increase? Does
+  the threshold differ between Go and TypeScript?
+- Apply this decomposition to a real monolithic module in your codebase.
+  Measure agent implementation quality before and after. Track: time to
+  correct implementation, number of review cycles, and defect density.
+- Design a module boundary linter that flags modules exceeding a configured
+  line count or dependency count. Integrate it into your CI pipeline. Set
+  the threshold at the size where your agents begin making cross-cutting
+  errors.

--- a/cotudes/PSA-004-the-evolutionary-architecture/README.md
+++ b/cotudes/PSA-004-the-evolutionary-architecture/README.md
@@ -1,0 +1,248 @@
+# PSA-004: The Evolutionary Architecture
+
+> **Axiom**: Design for the agent that will exist in two years, not the one that exists today.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Principal Software Architect |
+| **Number** | PSA-004 |
+| **Primary Competency** | Architecture for Agents |
+| **Secondary Competency** | Delegation Judgment |
+| **Trap Severity** | 2 (Fluency) |
+| **Prerequisites** | PSA-001, PSA-002, PSA-003 |
+| **Duration** | 2-3 sessions |
+| **Stack** | Architecture |
+
+## Overview
+
+You will evaluate two competing architecture proposals for the same system.
+One over-optimizes for current agent limitations -- fragmenting code into tiny
+files, adding excessive inline comments, duplicating context everywhere. The
+other ignores agents entirely -- relying on complex abstractions, implicit
+patterns, and human intuition. Both are wrong. You will design a third
+architecture that ages well as agent capabilities evolve.
+
+## Why Your Coding Agent Cares
+
+Today's agents struggle with certain patterns: deeply nested abstractions,
+implicit dispatch, files over a few thousand lines, convention-driven behavior
+without documentation. It is tempting to design architecture around these
+limitations. Some teams do: they cap files at 200 lines, inline documentation
+into every function, avoid metaprogramming entirely, and flatten inheritance
+hierarchies into explicit switch statements.
+
+This works today. It will be technical debt in 18 months.
+
+Agent capabilities are improving on a quarterly cadence. Context windows have
+grown from 4K to 200K tokens in two years. Tool use, multi-file reasoning,
+and codebase-wide search are standard. The agent that cannot follow a three-
+level abstraction today will follow it next quarter. The architecture you
+warped to avoid that abstraction will remain warped.
+
+The opposite failure is equally real. Architects who ignore agents design
+systems that assume a human reader will "just know" the patterns. They use
+convention-over-configuration frameworks where the file path *is* the routing
+rule, metaprogramming that generates code at build time, and implicit
+dependency injection that requires understanding the full container
+configuration. These patterns are powerful and well-understood by experienced
+engineers. They are opaque to agents today and will remain partially opaque
+for years, because they require reasoning about absent code -- code that
+exists only at runtime or by convention.
+
+The evolutionary architecture optimizes for principles that are stable across
+agent generations: explicit interfaces, discoverable conventions, documented
+invariants, and clear module boundaries. These are good architecture
+regardless of who or what is reading the code. They do not pander to current
+agent limitations, and they do not assume capabilities that do not yet exist.
+
+## The Setup
+
+The `starter/` directory contains two architecture proposals for **routesmith**,
+an API routing and middleware framework. Both proposals include design
+documents, directory structures, and partial implementations.
+
+```bash
+cd starter/
+ls proposals/
+# proposal-a/  -- the agent-optimized architecture
+# proposal-b/  -- the agent-ignorant architecture
+```
+
+**Proposal A** (agent-optimized) restructured the system to accommodate
+current agent limitations:
+
+- Every file is under 150 lines
+- Functions include inline doc comments restating the module-level docs
+- All middleware is explicit -- no chain composition, no dynamic dispatch
+- Configuration is duplicated across modules to avoid cross-file reads
+- Abstractions are flattened: no interfaces, concrete types everywhere
+- README files in every directory repeating context from parent READMEs
+
+**Proposal B** (agent-ignorant) uses sophisticated patterns a senior
+engineer would appreciate:
+
+- Convention-based middleware registration (drop a file in `middleware/`,
+  it is auto-registered based on filename sort order)
+- Generic middleware chain using type parameters and reflection
+- Code generation for route handlers from an OpenAPI spec
+- Dependency injection via a container with implicit binding rules
+- Domain logic expressed through a fluent builder API
+
+Both proposals include an `ADR.md` explaining the rationale.
+
+**Your assignment**: Evaluate both proposals. Then design a third architecture
+that will age well over 2-3 years of agent capability improvements. Implement
+the core module structure and document your architectural decisions.
+
+## Part 1: The Natural Approach
+
+You have likely developed a strong intuition for one of these two directions.
+Some architects, having experienced agent failures, lean toward Proposal A.
+Others, skeptical of designing around tool limitations, lean toward Proposal B.
+
+Pick the proposal closer to your instinct. Start a new agent session and ask
+the agent to implement a feature using that architecture:
+
+> "Add a new authentication middleware that supports both JWT and API key
+> authentication. It should integrate with the existing middleware chain,
+> support per-route configuration, and emit metrics for auth decisions."
+
+If you chose Proposal A, observe:
+- The agent has many small files to navigate. Does fragmentation help or
+  hinder comprehension?
+- Duplicated context: does the agent get confused by multiple sources of
+  truth, or does redundancy help?
+- No interfaces: how does the agent handle testing? Does it create test
+  doubles, or does it test against concrete implementations?
+
+If you chose Proposal B, observe:
+- Can the agent discover the convention-based registration?
+- Does it understand the generic middleware chain?
+- Can it work with the code-generated route handlers?
+- Does it find the implicit DI bindings?
+
+### Checkpoint
+
+- [ ] Did the agent produce a working implementation?
+- [ ] How many times did it misunderstand the architecture?
+- [ ] How many workarounds did it create because it could not follow the
+  intended pattern?
+- [ ] How much of the code would need to change if agent capabilities
+  improved significantly next quarter?
+- [ ] How much of the architecture is driven by the tool vs. by the domain?
+
+## Part 2: The Effective Approach
+
+Reset. Design the third architecture that follows evolutionary principles.
+
+Start by establishing your design criteria:
+
+**Keep (stable across agent generations):**
+- Explicit interfaces between modules
+- Documented invariants and constraints
+- Module boundaries sized for comprehension (not artificially small)
+- Concrete examples in documentation
+- Constructor injection for dependencies
+
+**Avoid (over-optimizing for current limitations):**
+- Artificially fragmenting files below natural cohesion boundaries
+- Duplicating context across locations (creates drift)
+- Eliminating all abstraction (loses expressiveness)
+- Inline comments that restate the code
+
+**Avoid (ignoring agents entirely):**
+- Convention-over-configuration without a discoverable manifest
+- Reflection-based dispatch without explicit registration fallback
+- Code generation without checked-in output
+- Implicit dependency resolution without a wiring file
+
+**Design for (likely near-term agent capabilities):**
+- Multi-file reasoning within a module
+- Codebase-wide search and reference following
+- Interface-based navigation (go-to-implementation)
+- Test execution and interpretation
+
+Write an `ADR-003.md` documenting your architecture. Include:
+- The principles guiding the design
+- What you chose NOT to optimize for and why
+- A 2-year review trigger: "Revisit these decisions when agents can X"
+
+Implement the core module structure. Then start a new agent session and give
+the same feature request. Observe how the agent navigates an architecture
+designed to be stable, not accommodating.
+
+### Checkpoint
+
+- [ ] Did the agent produce a correct implementation without workarounds?
+- [ ] Which of your architectural decisions actively helped the agent? Which
+  were neutral? Which were irrelevant?
+- [ ] Read your ADR-003 as if agent context windows doubled next month.
+  Which decisions still hold? Which would you revisit?
+- [ ] Compare the amount of architecture driven by domain concerns vs. tool
+  concerns. What is the ratio?
+
+## The Principle
+
+Architecture decisions have a half-life. The decisions that age best are the
+ones grounded in stable principles: separation of concerns, explicit
+contracts, information hiding. The decisions that age worst are the ones
+optimized for transient constraints: specific tool limitations, current team
+size, today's deployment infrastructure.
+
+Agent capabilities are a transient constraint. The specific things agents
+struggle with today -- long files, implicit patterns, convention-based
+dispatch -- are active areas of improvement. Designing architecture to avoid
+these specific limitations is the same mistake as designing architecture
+around a specific database's query planner quirks: it couples your system to
+an implementation detail that will change.
+
+The corollary is equally important: the things agents struggle with are often
+things humans struggle with too, just at different thresholds. A file that
+requires 200K tokens of context for an agent to understand correctly probably
+requires more cognitive load than any single human should bear. The right
+response is not to fragment it for the agent -- it is to design module
+boundaries that serve both human cognition and agent reasoning.
+
+Evolutionary architecture means making decisions that are robust to
+capability changes in either direction. If agents get dramatically better,
+your architecture should not need restructuring. If agents plateau, your
+architecture should still be correct. The way to achieve this is to design
+for the domain, not the tool.
+
+> **Design for the agent that will exist in two years, not the one that exists today.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Instinct check**: Which proposal did you initially lean toward? What
+   does that reveal about your mental model of agent-assisted development?
+2. **Over-optimization audit**: Look at your current systems. Where have you
+   (or your team) made architectural decisions specifically to accommodate
+   agent limitations? Which of those decisions will age well?
+3. **Under-optimization audit**: Where are you using patterns that are
+   opaque to agents (convention-based dispatch, implicit registration,
+   build-time code generation) without providing discoverable alternatives?
+4. **Time horizon**: What is the half-life of your architectural decisions?
+   Which decisions made two years ago are now technical debt because the
+   tooling landscape changed?
+5. **Review triggers**: What specific agent capability improvements would
+   cause you to revisit your current architectural decisions?
+
+## Going Further
+
+- Inventory the architectural decisions in your most critical system. Tag
+  each as "domain-driven," "agent-accommodating," or "agent-ignoring."
+  For each agent-accommodating decision, write a review trigger: "Revisit
+  when agents can ___." For each agent-ignoring decision, assess: does this
+  create unnecessary friction for agent-assisted development?
+- Design an architectural fitness function that measures how well a codebase
+  supports agent-assisted development without over-optimizing for current
+  limitations. Candidate metrics: average module size, interface coverage,
+  documentation-to-code ratio, convention discoverability score.
+- Write an ADR template for your organization that includes a "Tool
+  Sensitivity" section: which decisions in this ADR are sensitive to
+  changes in development tooling (including agents), and what are the
+  review triggers?

--- a/cotudes/PSA-005-documentation-as-code/README.md
+++ b/cotudes/PSA-005-documentation-as-code/README.md
@@ -1,0 +1,241 @@
+# PSA-005: Documentation as Code
+
+> **Axiom**: Documentation the agent can't find is documentation that doesn't exist.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Principal Software Architect |
+| **Number** | PSA-005 |
+| **Primary Competency** | Context Engineering |
+| **Trap Severity** | 3 (Intermediate) |
+| **Prerequisites** | PSA-001, PSA-002 |
+| **Duration** | 2-3 sessions |
+| **Stack** | Any (Go / TypeScript examples) |
+
+## Overview
+
+You will add a feature to a system whose architecture is thoroughly documented
+-- in a wiki the agent cannot access. The documentation is accurate, detailed,
+and completely invisible to the agent. The agent will violate documented
+patterns because, from its perspective, those patterns do not exist. Then you
+will move the documentation into the codebase and watch the same agent follow
+every pattern without being told.
+
+## Why Your Coding Agent Cares
+
+Most organizations have good documentation. It lives in Confluence, Notion,
+Google Docs, or a SharePoint site. It describes module responsibilities, data
+flow invariants, deployment constraints, and cross-cutting concerns. Senior
+engineers wrote it carefully and keep it reasonably current. The problem is not
+quality. The problem is location.
+
+When an agent begins work on a codebase, it reads what is in front of it: source
+files, configuration, tests, and any documentation committed alongside the code.
+It does not have credentials to your wiki. It does not know the wiki exists. If
+you paste excerpts into the prompt, the agent gets a snapshot -- frozen in time,
+stripped of cross-references, missing the three paragraphs of context that
+surround the excerpt. The agent operates on what it can see, and what it can see
+is incomplete.
+
+The failure is quiet. The agent produces code that is internally consistent,
+passes tests, and violates an architectural pattern described on page four of
+your Confluence space. In review, you catch it -- because you read the
+Confluence page last month. Next quarter a new hire misses the same violation,
+because they did not read the Confluence page either. The documentation exists.
+It just does not exist where it matters.
+
+Documentation as code means architecture documentation lives in the repository,
+versioned alongside the code it describes. ARCHITECTURE.md at the repo root.
+ADRs in `docs/decisions/`. README files in each package describing
+responsibilities and constraints. Type-level encodings of invariants that make
+illegal states unrepresentable. When the agent explores the codebase, it finds
+these files automatically as part of context discovery. No special instructions,
+no pasted excerpts, no wiki credentials. The documentation is where the work
+happens.
+
+## The Setup
+
+The `starter/` directory contains **clairvoy**, an event analytics pipeline
+with three services: an ingestion API, a stream processor, and a query engine.
+The system processes clickstream events, enriches them with session data, and
+serves aggregated metrics through a REST API.
+
+```bash
+cd starter/
+# Go variant
+go build ./...
+go test -race -count=1 ./...
+
+# TypeScript variant
+npm install && npm test
+```
+
+The codebase works. The tests pass. The architecture documentation lives
+in `wiki/` -- a directory containing Markdown files that simulate an external
+wiki. These files describe:
+
+- **Service boundaries**: which service owns which data, and what crosses
+  service boundaries via events vs. API calls
+- **Event schema conventions**: all events use CloudEvents envelope format,
+  with `type` field following `com.clairvoy.<domain>.<action>` naming
+- **Idempotency requirements**: every event handler must be idempotent;
+  the stream processor guarantees at-least-once delivery
+- **Query engine constraints**: aggregation queries must use pre-computed
+  materialized views, never scan raw events at query time
+- **Deployment invariant**: the ingestion API and stream processor share no
+  runtime state; all coordination happens through the event bus
+
+The wiki documentation is accurate. It is also outside the agent's natural
+discovery path.
+
+**Your assignment**: Add a new "user journey" analytics feature. The ingestion
+API receives a new `JourneyStepCompleted` event type. The stream processor
+enriches it with session context and emits a `JourneyAnalyzed` event. The
+query engine serves journey completion funnels through a new endpoint.
+
+## Part 1: The Natural Approach
+
+Start your agent in the `starter/` directory. Describe the feature:
+
+> "Add a user journey analytics feature. The ingestion API should accept
+> JourneyStepCompleted events. The stream processor should enrich them with
+> session context and emit JourneyAnalyzed events. The query engine should
+> serve journey completion funnels through a new REST endpoint."
+
+Do not mention the wiki. Do not paste excerpts. Let the agent work with what
+it finds in the codebase.
+
+Run the tests. They will likely pass.
+
+### Checkpoint
+
+Inspect the agent's implementation against the wiki documentation:
+
+- [ ] Does the new event use CloudEvents envelope format with the correct
+  `type` field naming convention (`com.clairvoy.journey.step-completed`)?
+- [ ] Is the stream processor handler idempotent? Can it safely process the
+  same event twice without double-counting journey steps?
+- [ ] Does the query engine endpoint use a materialized view, or does it scan
+  raw events at query time?
+- [ ] Does the implementation respect service boundaries -- no shared runtime
+  state between ingestion and stream processor?
+- [ ] Does the event schema follow the conventions described in the wiki?
+
+Now try the halfway measure. Paste the relevant wiki sections into the agent's
+context and ask it to fix the violations:
+
+> "Here are our architecture docs: [paste]. Please update the implementation
+> to follow these patterns."
+
+Observe: does the agent fix the specific violations you highlighted while
+introducing new ones from the context it still lacks? Does it treat the pasted
+excerpts as suggestions or constraints?
+
+## Part 2: The Effective Approach
+
+Reset the codebase. Before starting a new session, move the documentation into
+the repository:
+
+1. Create `ARCHITECTURE.md` at the repo root summarizing service boundaries,
+   data flow, and cross-cutting invariants.
+
+2. Create `docs/decisions/` with ADRs for the key architectural choices:
+   - `ADR-001-cloudevents-envelope.md` -- why CloudEvents, the naming convention,
+     the envelope structure
+   - `ADR-002-idempotent-handlers.md` -- at-least-once delivery guarantee,
+     idempotency key strategy, deduplication window
+   - `ADR-003-materialized-views.md` -- no raw event scans at query time,
+     materialized view refresh strategy, consistency tradeoffs
+
+3. Add a `README.md` to each service directory describing that service's
+   responsibilities, its public interface, and what it must never do.
+
+4. Where possible, encode constraints as types: an `EventEnvelope` struct
+   that enforces the CloudEvents shape, an `IdempotencyKey` type that the
+   handler signature requires, a query builder that only accepts materialized
+   view references.
+
+Delete the `wiki/` directory. The documentation now lives where the code lives.
+
+Start a new agent session. Give the identical feature request. Do not mention
+the documentation -- the agent will find it.
+
+### Checkpoint
+
+- [ ] How many architectural violations remain compared to Part 1?
+- [ ] Did the agent discover and reference ARCHITECTURE.md, the ADRs, or the
+  package READMEs without being told to?
+- [ ] Did the type-level constraints prevent violations at compile time rather
+  than requiring documentation to be read?
+- [ ] Compare: same feature, same agent, same prompt. The only variable is
+  where the documentation lives. What changed?
+
+## The Principle
+
+Documentation has two audiences: the person deciding whether the architecture
+is correct, and the person (or agent) implementing within it. Wiki-based
+documentation serves the first audience well. It is browsable, searchable for
+humans, and supports rich cross-linking. It is invisible to the second audience
+when that audience is an agent.
+
+This is not an argument against wikis. It is an argument for redundancy in the
+right direction. The canonical architecture documentation belongs in the
+repository because that is where implementation happens. A wiki can mirror it,
+summarize it, or link to it. But the source of truth must be where the
+implementer -- human or agent -- will find it without being told where to look.
+
+The deeper principle is about context discovery. Agents do not ask clarifying
+questions about documentation they do not know exists. They do not search wikis
+they cannot access. They work with what they find. If your architecture depends
+on documentation that requires a login, a bookmark, or institutional knowledge
+to locate, it depends on documentation that does not exist for an agent.
+
+The fix is not "tell the agent about the wiki." The fix is to make the
+documentation discoverable by default: in the repo, at predictable paths,
+following conventions the agent already knows to look for. ARCHITECTURE.md,
+ADRs, package-level READMEs, type-level constraints. These are not novel ideas.
+They are standard practice that most teams skip because the wiki was good
+enough for humans.
+
+It was. It is not good enough for agents. And if you are honest, it was not
+good enough for the new hire on their second week either.
+
+> **Documentation the agent can't find is documentation that doesn't exist.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Audit**: Where does your architecture documentation live right now? How
+   many clicks, logins, or bookmarks does it take to get from the code to the
+   relevant doc? That is the distance the agent cannot cross.
+2. **Discovery test**: Clone your repo into a fresh environment. Without any
+   external access, can you determine the architectural constraints? If you
+   cannot, neither can the agent.
+3. **Excerpt fragility**: When you pasted wiki excerpts in Part 1, what
+   context was lost? Cross-references to other docs? Version history showing
+   why a decision was made? Related constraints on the same page?
+4. **Type vs. doc**: Which constraints were more effectively communicated
+   through types than through documentation? Where did types make documentation
+   redundant?
+5. **Maintenance cost**: What is the ongoing cost of keeping in-repo
+   documentation current? How does it compare to the cost of wiki documentation
+   drift -- which is the same cost, just invisible until someone (or something)
+   violates a stale doc?
+
+## Going Further
+
+- Run the discovery test on your three most critical services. For each,
+  catalog: what architectural knowledge is only in the wiki? What is only in
+  people's heads? What is in the repo? Create a migration plan to move the
+  critical subset into the codebase.
+- Design an ADR template that serves both human reviewers and agent
+  implementers. Include: decision, constraints (as checkable assertions),
+  examples (as concrete input/output pairs), and anti-patterns (what the
+  implementation must NOT do).
+- Measure the impact: have an agent implement the same feature in a repo
+  with wiki-only docs, then with in-repo docs, then with in-repo docs plus
+  type-level constraints. Track invariant violations across the three runs.
+  Plot the curve. Show it to your team.

--- a/cotudes/PSA-011-system-redesign/README.md
+++ b/cotudes/PSA-011-system-redesign/README.md
@@ -1,0 +1,209 @@
+# PSA-011: System Redesign (CAPSTONE DRAFT)
+
+> **Axiom**: A system designed for agent collaboration is a system designed for clarity. There is no difference.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Principal Software Architect |
+| **Number** | PSA-011 |
+| **Primary Competency** | All |
+| **Trap Severity** | N/A (Capstone) |
+| **Prerequisites** | PSA-001 through PSA-010 |
+| **Duration** | 5-8 sessions |
+| **Stack** | Architecture + Code |
+
+## Overview
+
+You will take an existing production system -- one you know well, with real
+complexity, real history, and real scars -- and redesign it as if agent
+collaboration were a first-class architectural concern. Not a retrofit. Not
+"add ARCHITECTURE.md and call it done." A redesign that reconsiders module
+boundaries, specification formats, documentation placement, invariant
+enforcement, observability, and evolution strategy through the lens of
+everything you have practiced in PSA-001 through PSA-010.
+
+This is a capstone. It synthesizes every competency in the path. The output is
+not a toy system -- it is a redesign proposal and partial implementation for a
+system that matters to you.
+
+## Scenario
+
+You are the principal architect on a system that was designed before agent-
+assisted development was a serious consideration. The system works. It has
+users, SLAs, and an on-call rotation. It also has:
+
+- Module boundaries that evolved organically around team ownership rather
+  than cognitive or context-window coherence
+- Architecture documentation in a wiki, partially stale, partially excellent
+- Invariants enforced by convention, tribal knowledge, and code review
+- Specifications written as prose RFCs aimed at architecture review boards
+- Observability designed for human operators reading dashboards, not for
+  agents interpreting telemetry programmatically
+- A change history that makes sense to people who were there and is opaque
+  to anyone (or anything) arriving fresh
+
+Your CTO asks: "If we were designing this system today, knowing that half of
+feature development will involve agent collaboration within a year, what would
+we change?" Not "rewrite from scratch." Not "add AI features." What structural
+changes to the architecture would make the system fundamentally more effective
+to work on with agents?
+
+You have 5-8 sessions to answer that question with a redesign proposal and
+enough implementation to prove the critical ideas work.
+
+## Deliverables
+
+### 1. System Assessment (Session 1-2)
+
+Analyze your chosen system against the competencies from PSA-001 through
+PSA-010. For each, score the current state and identify the highest-leverage
+change.
+
+| Competency | Current State | Key Gap | Proposed Change |
+|-----------|---------------|---------|-----------------|
+| Implicit vs. explicit invariants (PSA-001) | | | |
+| Specification as contract (PSA-002) | | | |
+| Module boundary coherence (PSA-003) | | | |
+| Evolutionary architecture (PSA-004) | | | |
+| Documentation as code (PSA-005) | | | |
+| [PSA-006 through PSA-010] | | | |
+
+Be ruthless. Score against what an agent would experience, not what your
+team has learned to work around.
+
+### 2. Redesign Proposal (Session 2-3)
+
+An architecture document -- in the repo, not a wiki -- covering:
+
+**Module boundaries**: Redraw the module map with two constraints in mind.
+First, each module should be comprehensible within a single agent context
+window (today: ~200K tokens of source, tests, and documentation). Second,
+module interfaces should be explicit enough that an agent working in module A
+never needs to read module B's internals to use it correctly.
+
+**Documented invariants**: For every invariant currently enforced by tribal
+knowledge, choose one of three strategies: encode it in the type system,
+enforce it with a test, or document it in an ADR. Rank by blast radius --
+start with the invariants whose violation causes the worst production
+incidents.
+
+**ADRs as implementation contracts**: Rewrite the three most critical
+architectural decisions as contract-style ADRs (per PSA-002). Include:
+interface signatures, constraint boundaries, error behavior, concrete
+examples, and anti-patterns. These ADRs are not just records of decisions --
+they are implementation specs an agent can follow.
+
+**Observability for agent-generated code**: Design an observability strategy
+that answers: "Did the code the agent wrote behave correctly in production?"
+This means structured telemetry that can be queried programmatically, not
+dashboards designed for human pattern recognition. Specific signals: error
+rates by code author (human vs. agent), latency distributions for new code
+paths, invariant violation counters that fire before the customer notices.
+
+**Evolution strategy**: Define review triggers for every major decision in the
+proposal. "Revisit module boundary sizes when agent context windows reach X."
+"Revisit type-level invariant encoding when agents can Y." The redesign should
+be stable for 2 years but explicitly designed to be revised.
+
+### 3. Proof of Concept (Session 3-6)
+
+Pick the two highest-leverage changes from the proposal and implement them
+against the real system (or a representative subset). The implementation
+should be real enough that you can:
+
+- Start an agent session in the redesigned module and have it add a feature
+- Compare the agent's output against the same feature added in the original
+  architecture
+- Measure the difference in invariant violations, implementation accuracy,
+  and time to correct output
+
+This is not a complete rewrite. It is a surgical proof that the redesign
+ideas work in practice, not just on paper.
+
+### 4. Agent Validation (Session 5-7)
+
+Use an agent to implement a non-trivial feature in the redesigned portion
+of the system. Document:
+
+- What the agent discovered on its own (ARCHITECTURE.md, ADRs, package
+  READMEs, type constraints)
+- What the agent got right without guidance
+- What the agent still got wrong, and whether the failure was a gap in the
+  redesign or a current agent limitation
+- How the observability signals performed: did they catch the agent's
+  mistakes? How quickly?
+
+Run the same feature request against the original architecture as a control.
+The comparison is the evidence.
+
+### 5. Retrospective Document (Session 7-8)
+
+A written retrospective covering:
+
+- Which redesign ideas had the highest impact? Which were surprisingly
+  irrelevant?
+- What did you learn about your system's architecture by evaluating it
+  through the agent collaboration lens?
+- What would you prioritize if you could only make three changes to the
+  production system next quarter?
+- Where did your instincts as an architect conflict with what the evidence
+  showed? When were your instincts right anyway?
+
+## Constraints
+
+- **Use a real system.** A toy project will not surface the hard problems:
+  organic module boundaries, stale documentation, tribal knowledge, historical
+  decisions that made sense at the time. If you cannot use your production
+  system, use the most complex open-source system you actively contribute to.
+
+- **Do not boil the ocean.** The redesign proposal covers the full system.
+  The implementation covers two modules. The agent validation covers one
+  feature. Scope ruthlessly. A narrow proof that works is worth more than a
+  broad proposal that stays on paper.
+
+- **Keep the redesign deployable.** Every change you propose must be
+  incrementally adoptable. "Rewrite in Rust" is not a redesign -- it is a
+  fantasy. "Introduce explicit interfaces between the billing and accounts
+  modules, documented with contract-style ADRs" is a redesign that can ship
+  next sprint.
+
+- **Version everything.** The assessment, proposal, ADRs, implementation, and
+  retrospective all live in the repository. Commit history should tell the
+  story of the redesign.
+
+## Evaluation Criteria
+
+This is a self-evaluated capstone. Score yourself honestly.
+
+| Criterion | Question |
+|-----------|----------|
+| **Depth of assessment** | Did you identify invariants and gaps that surprised you, or only the obvious ones? |
+| **Specificity of proposal** | Could another architect implement your proposal without asking clarifying questions? |
+| **Contract quality** | Are the ADRs precise enough that an agent could implement against them without prose interpretation? |
+| **Proof of concept rigor** | Does the implementation prove the ideas work, with measurable before/after comparison? |
+| **Agent validation honesty** | Did you report what the agent actually did, including where the redesign failed to help? |
+| **Incrementalism** | Can every proposed change ship independently, without requiring a coordinated rewrite? |
+| **Evolution awareness** | Does the proposal include explicit review triggers, or does it assume the redesign is permanent? |
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Hardest decision**: What was the single hardest architectural decision
+   in the redesign? Not the most complex -- the one where the tradeoffs were
+   most finely balanced. What did you choose, and what did you give up?
+2. **Tribal knowledge inventory**: How many invariants did you discover that
+   existed only in people's heads? How many of those had caused production
+   incidents? How many will you actually move into the codebase?
+3. **Module boundary surprise**: When you redrew module boundaries for context
+   window coherence, did the new boundaries align with team ownership
+   boundaries? If not, what does that tell you about how your teams are
+   organized?
+4. **Observability gap**: What did the agent-oriented observability strategy
+   reveal about your current observability? Are you monitoring for the right
+   signals, or for the signals that were easy to add?
+5. **Honest assessment**: If you shipped this redesign, how much of the
+   benefit accrues to agent collaboration specifically, and how much is just
+   better architecture that helps everyone? Is there a difference?

--- a/cotudes/STE-002-spec-driven-development/README.md
+++ b/cotudes/STE-002-spec-driven-development/README.md
@@ -1,0 +1,215 @@
+# STE-002: Spec-Driven Development
+
+> **Axiom**: The spec isn't overhead -- it's the interface between your intent and the agent's execution.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff Software Engineer |
+| **Number** | STE-002 |
+| **Primary Competency** | Specification Writing |
+| **Secondary Competency** | Context Engineering |
+| **Trap Severity** | 4 (Expert) |
+| **Prerequisites** | STE-001 (The CLAUDE.md) |
+| **Duration** | 120-180 minutes |
+| **Stack** | Go |
+
+## Overview
+
+You will implement a cross-service feature -- adding a "team assignment" capability
+that touches an API service, a database migration, and a notification worker. The
+feature requires coordinated changes across three packages with shared data
+contracts. How you communicate intent to the agent determines whether the pieces
+integrate.
+
+## Why Your Coding Agent Cares
+
+An agent given the instruction "add team assignment to the project service" will
+produce working code. It will pick reasonable field names, sensible types, and
+plausible error handling. The problem is that "reasonable" choices made independently
+across three components almost never align. The API returns `team_id` as a string;
+the migration creates it as an integer. The notification worker expects
+`assigned_at` as RFC 3339; the API serializes it as Unix epoch. Each piece compiles.
+Each piece passes its own tests. Integration fails.
+
+This happens because agents optimize locally. When generating the API handler, the
+agent's context is the handler code. When generating the migration, the context is
+the schema. There is no shared contract binding the two unless you provide one. The
+agent doesn't "forget" the API when writing the migration -- it never had the API's
+decisions as hard constraints in the first place.
+
+A spec document changes the agent's relationship to each component. Instead of
+inventing conventions per-component, the agent implements against an explicit
+contract: field names, types, formats, error codes, and validation rules defined
+once. The spec becomes the source of truth the agent references for every decision.
+You write the spec in 15 minutes. It saves you 90 minutes of integration debugging.
+
+This is the same principle as writing interface contracts between teams -- except
+your "teams" are separate agent sessions (or separate prompts within a session),
+and they cannot coordinate with each other. The spec is their only communication
+channel.
+
+## The Setup
+
+The `starter/` directory contains **taskflow**, the same task management service
+from STE-001, now extended with three packages:
+
+- `internal/api/` -- HTTP handlers for the REST API
+- `internal/store/` -- Database access layer (SQLite)
+- `internal/notify/` -- Notification worker that processes events
+
+The service currently supports users, tasks, and projects. Your assignment is to
+add **team assignment**: the ability to assign a team of users to a project, with
+notifications sent when assignments change.
+
+This requires:
+
+1. **API changes**: New endpoints for team management (`POST /projects/{id}/team`,
+   `GET /projects/{id}/team`, `DELETE /projects/{id}/team/{user_id}`)
+2. **Database migration**: New `project_teams` table with membership tracking and
+   timestamps
+3. **Notification worker**: Events emitted on team changes, consumed by the
+   notification worker to send assignment notifications
+
+Acceptance criteria:
+- All three components use identical field names and types for shared data
+- Timestamps are consistently formatted across all components
+- Error codes from the API match what the notification worker expects
+- The migration schema matches what the store layer queries
+- All existing tests continue to pass; new tests cover the team feature
+
+```bash
+cd starter/
+go build ./...
+go test -race -count=1 ./...
+```
+
+## Part 1: The Natural Approach
+
+You know what team assignment looks like. You have built features like this many
+times. Start implementing.
+
+Open your agent and give it the full task: add team assignment to the project
+service, covering the API, database, and notification components. Let the agent
+work through each component. You can do this in a single session or across
+multiple prompts -- whatever feels natural.
+
+Do not write a spec or contract document first. You are an experienced engineer;
+you can describe the feature clearly enough. Let the agent interpret your intent
+for each component.
+
+When the agent finishes all three components, integrate them. Run the tests.
+Attempt to exercise the full flow: create a team assignment via the API, verify
+it is persisted correctly, confirm the notification worker processes the event.
+
+Record in your interaction log:
+1. The exact field names each component uses for the same concept
+2. The timestamp format each component uses
+3. The error handling pattern in each component
+4. How many integration issues you found
+5. How long you spent fixing integration mismatches
+
+### Checkpoint
+
+- [ ] Do the API response field names exactly match the database column names
+      where they should?
+- [ ] Does the notification worker parse the event payload without type
+      conversion or field renaming?
+- [ ] Are timestamps in the same format across all three components?
+- [ ] Did error codes from the API layer match what the worker expects?
+- [ ] How many "glue code" fixes did you need to make the pieces fit?
+- [ ] How many of those fixes were the agent's fault vs. ambiguity in your
+      instructions?
+
+## Part 2: The Effective Approach
+
+Reset the codebase to its original state.
+
+Before touching any code, write a **feature spec** document. This is not a product
+requirements document -- it is a technical contract. Create a file called
+`specs/team-assignment.md` in the project root.
+
+Your spec must define:
+
+1. **Data model**: Exact field names, types, and constraints for the
+   `project_teams` table. Column names, Go struct field names, and JSON field
+   names -- all three.
+2. **API contract**: Request/response schemas for each endpoint. Exact JSON
+   field names, types, status codes, and error response format.
+3. **Event contract**: The exact payload structure for team change events.
+   Field names, types, timestamp format (pick one: RFC 3339).
+4. **Shared constants**: Error codes, status values, any enumerated types.
+5. **Validation rules**: Which fields are required, length limits, foreign key
+   constraints.
+
+The spec should be 40-80 lines. Dense, no prose. Tables and code blocks.
+
+Now implement the feature. For each component, include the spec in your prompt:
+"Implement the API endpoints defined in this spec" with the relevant sections
+pasted or referenced. The agent implements against the contract, not against its
+own interpretation of the feature.
+
+After all components are built, integrate and test.
+
+### Checkpoint
+
+- [ ] Do field names match across all three components without manual fixes?
+- [ ] Do timestamp formats match without conversion code?
+- [ ] Did the notification worker parse API events without modification?
+- [ ] How many integration fixes were needed? (Compare to Part 1.)
+- [ ] How long did the spec take to write vs. how much integration time it saved?
+- [ ] Did the agent ever deviate from the spec? If so, was the spec ambiguous?
+
+Compare your spec against `reference/specs/team-assignment.md`.
+
+## The Principle
+
+Staff engineers carry system design in their heads. You know how the pieces
+connect because you have built systems like this before. That mental model is
+precise enough to write correct code yourself. It is not precise enough to
+transfer to an agent through natural language instructions.
+
+The gap is not intelligence -- it is context. When you tell an agent to "add team
+assignment," the agent has no access to the decisions you have already made in
+your head: that `user_id` is a UUID string, that timestamps are RFC 3339, that
+error responses use a `code` field. The agent makes its own decisions. They are
+reasonable. They are different from yours. And they are different from each other
+across components.
+
+A spec externalizes your mental model into a document the agent can reference.
+It turns implicit decisions into explicit constraints. The cost is 15-20 minutes
+of writing. The return is integration that works on the first attempt.
+
+This pattern scales. A spec for a two-component feature saves you an hour. A spec
+for a six-service feature saves you a day. The larger the system, the more the
+spec pays for itself -- because the number of implicit decisions grows
+combinatorially with the number of components.
+
+> **The spec isn't overhead -- it's the interface between your intent and the agent's execution.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Integration delta**: Count the integration issues in Part 1 vs. Part 2.
+   What is the ratio?
+2. **Spec as debugging tool**: When an integration issue occurred in Part 2,
+   was it because the agent deviated from the spec or because the spec was
+   incomplete? Which is easier to fix?
+3. **Spec granularity**: Which parts of your spec were most valuable? Which
+   were unnecessary? What is the minimum viable spec for this feature?
+4. **Mental model audit**: What decisions did you not realize you had made
+   until writing the spec? List them.
+5. **Resistance check**: Did writing the spec feel like unnecessary overhead?
+   How do you feel about it now?
+
+## Going Further
+
+- Take the feature spec and ask the agent to implement the same feature in a
+  language you do not know well. Does the spec transfer across language barriers?
+- Write a spec for a feature you are currently building at work. Use it with
+  your agent. Measure integration issues against your last unspecced feature.
+- Try having the agent write the first draft of the spec from a product
+  requirements description, then review and tighten it yourself. Compare the
+  quality of output when the agent writes against its own spec vs. yours.

--- a/cotudes/STE-003-the-delegation-matrix/README.md
+++ b/cotudes/STE-003-the-delegation-matrix/README.md
@@ -1,0 +1,213 @@
+# STE-003: The Delegation Matrix
+
+> **Axiom**: Delegate what's easily verified, not what's boring.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff Software Engineer |
+| **Number** | STE-003 |
+| **Primary Competency** | Delegation Judgment |
+| **Secondary Competency** | Output Evaluation |
+| **Trap Severity** | 4 (Expert) |
+| **Prerequisites** | STE-001 (The CLAUDE.md), STE-002 (Spec-Driven Development) |
+| **Duration** | 120-150 minutes |
+| **Stack** | Go |
+
+## Overview
+
+You face a realistic day of work: implement a rate-limiting algorithm, build three
+CRUD API endpoints, write a database migration script, and improve test coverage
+for an existing package. You will delegate some of these to an agent and do the
+rest yourself. Which tasks you delegate -- and why -- determines the outcome.
+
+## Why Your Coding Agent Cares
+
+Experienced engineers have a reliable heuristic for what is "interesting" vs.
+"boring" work. Algorithms are interesting. CRUD endpoints are boring. Migration
+scripts are boring. Test coverage is tedious. The instinct is to delegate the
+boring parts and keep the interesting parts.
+
+This heuristic is backwards for agent delegation.
+
+An agent excels at tasks with two properties: **easy to specify** and **easy to
+verify**. CRUD endpoints are both. You can describe them in a sentence ("create a
+REST endpoint for the `teams` resource with standard CRUD operations"). You can
+verify them in seconds (run the tests, hit the endpoint, check the response).
+Migration scripts are similar: the schema is the spec, the migration is the
+implementation, and `go test` verifies it.
+
+A rate-limiting algorithm is neither. Specifying a token bucket with sliding
+window, burst handling, and distributed state requires a level of precision that
+approaches writing the code itself. Verifying correctness requires reasoning about
+edge cases: what happens at exactly the burst boundary? What if two requests
+arrive in the same nanosecond? What is the behavior under clock skew? You cannot
+verify these by glancing at the output -- you have to think deeply about each case.
+That is the work you are good at. That is the work you should keep.
+
+The delegation error is conflating "what I find tedious" with "what the agent
+handles well." They are orthogonal axes. The matrix has four quadrants, and most
+engineers only see two.
+
+## The Setup
+
+The `starter/` directory contains **taskflow** with a new requirement set. You
+have four tasks to complete today:
+
+**Task A -- Rate Limiter**: Implement a token bucket rate limiter with sliding
+window support for the API. Requirements: per-client limiting, configurable burst
+size, distributed-safe (must work behind a load balancer with shared Redis state),
+graceful degradation when Redis is unavailable. The algorithm must handle edge
+cases around window boundaries and concurrent access.
+
+**Task B -- Three API Endpoints**: Add CRUD endpoints for a new `labels` resource.
+Labels have a name, color (hex string), and project association. Standard REST
+patterns: create, read, list-with-filter, update, delete. Follow existing
+conventions from the `tasks` and `projects` resources.
+
+**Task C -- Migration Script**: Write a migration that adds the `labels` table,
+a `task_labels` join table, and backfills a `default` label for every existing
+project. Must be idempotent and include a rollback.
+
+**Task D -- Test Coverage**: The `internal/store/` package has 45% test coverage.
+Add table-driven tests to bring it to 80%+. Tests must cover error paths, not
+just happy paths.
+
+```bash
+cd starter/
+go build ./...
+go test -race -count=1 ./...
+go test -cover ./internal/store/...
+```
+
+All four tasks must be completed. You have approximately 2 hours of implementation
+time (not counting evaluation). Plan your time accordingly.
+
+## Part 1: The Natural Approach
+
+Look at the four tasks. Decide which ones to delegate to the agent and which to
+do yourself. Spend no more than 2 minutes deciding -- go with your gut.
+
+Write down your delegation decision before starting:
+- Task A (Rate Limiter): Agent / Self
+- Task B (API Endpoints): Agent / Self
+- Task C (Migration): Agent / Self
+- Task D (Test Coverage): Agent / Self
+
+Now execute. For the tasks you delegated, prompt the agent and review the output.
+For the tasks you kept, write the code yourself. Track time spent on each task,
+including review and correction time for agent-generated work.
+
+Record in your interaction log:
+1. Your delegation decision and reasoning
+2. Time spent on each task (implementation + review + correction)
+3. Number of issues found in agent output that required rework
+4. Your confidence in the correctness of each deliverable
+
+### Checkpoint
+
+- [ ] Which delegated tasks required significant rework?
+- [ ] Which self-implemented tasks could the agent have done as well or better?
+- [ ] For the rate limiter: if you delegated it, how many edge case bugs did you
+      find? If you kept it, how long did it take vs. the CRUD endpoints?
+- [ ] For the CRUD endpoints: if you kept them, was that time well spent?
+- [ ] What was your total time? How much was implementation vs. review/correction?
+- [ ] Did the agent struggle with any task you expected it to handle easily?
+
+## Part 2: The Effective Approach
+
+Reset the codebase. This time, delegate using the verification-cost heuristic:
+**delegate tasks where you can verify correctness quickly; keep tasks where
+verification requires deep reasoning.**
+
+The delegation matrix:
+
+| Task | Specify | Verify | Delegate? |
+|------|---------|--------|-----------|
+| A: Rate Limiter | Hard (edge cases, distributed semantics) | Hard (concurrency, boundary conditions) | **Self** |
+| B: API Endpoints | Easy (follow existing patterns) | Easy (run tests, hit endpoints) | **Agent** |
+| C: Migration | Easy (schema is the spec) | Easy (run migration, check schema) | **Agent** |
+| D: Test Coverage | Medium (need to identify gaps) | Easy (run coverage tool) | **Agent** |
+
+For each delegated task, write a brief spec (2-5 sentences) that the agent can
+implement against. Reference existing patterns in the codebase. For Tasks B and C,
+include the exact field names and types from your data model.
+
+For Task A, implement the rate limiter yourself. You are the right person for
+this: you can reason about the edge cases as you write, adjust the design in
+real time, and verify correctness through your understanding of the algorithm.
+
+For Task D, give the agent the current coverage report and ask it to target
+the uncovered paths. Review the tests it generates -- you are checking that the
+tests are meaningful, not just that they pass.
+
+Track the same metrics as Part 1.
+
+### Checkpoint
+
+- [ ] Compare total time between Part 1 and Part 2.
+- [ ] Compare rework time on agent-delegated tasks.
+- [ ] For the rate limiter: compare your confidence in correctness between
+      approaches. If you delegated it in Part 1, did you catch all the edge cases?
+- [ ] For the CRUD endpoints: compare quality when agent-generated with a spec
+      vs. your initial approach.
+- [ ] How much review time did the easily-verified tasks require?
+- [ ] Did you finish all four tasks? In which part did you finish faster?
+
+## The Principle
+
+The delegation instinct of a staff engineer is shaped by years of individual
+contribution. You delegate what you find tedious because you want to spend your
+time on the hard problems. This is rational when the person you delegate to
+has the same context you do -- a junior engineer can ask clarifying questions,
+notice ambiguity, push back on underspecified requirements.
+
+An agent cannot. It will produce output for any task, regardless of how well
+specified. The difference is in what it produces. For a well-specified task
+(CRUD endpoints matching existing patterns), the output is reliably correct.
+For an underspecified task (a rate limiter with subtle concurrency requirements),
+the output is confidently wrong -- it compiles, it passes basic tests, and it
+fails in production under edge cases you did not think to test.
+
+The verification cost is the key variable. After the agent delivers:
+- CRUD endpoints: run tests, check response format, done. 5 minutes.
+- Rate limiter: reason about burst boundaries, concurrent access, clock skew,
+  Redis failure modes, window edge cases. 45 minutes -- if you catch everything.
+
+When verification costs approach implementation costs, delegation saves nothing.
+When verification is fast and reliable, delegation multiplies your throughput.
+
+Map your daily work onto two axes: specification difficulty and verification
+cost. Delegate the bottom-left quadrant (easy to specify, easy to verify).
+Keep the top-right quadrant (hard to specify, hard to verify). The other two
+quadrants require judgment, but the extremes are clear.
+
+> **Delegate what's easily verified, not what's boring.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Decision audit**: What was your gut delegation in Part 1? How did it map
+   to the specification/verification matrix?
+2. **Verification time**: For each delegated task, how long did verification
+   take? Was the time proportional to the task's position on the matrix?
+3. **Confidence gap**: For the rate limiter, compare your confidence in the
+   agent's implementation vs. your own. What specifically drives the difference?
+4. **Work inventory**: List five tasks from your last week at work. Place each
+   on the specification/verification matrix. Which should you delegate?
+5. **Ego check**: Did you resist delegating the CRUD endpoints because they
+   felt "too easy"? Did you resist keeping the algorithm because it felt like
+   the agent "should" handle hard things?
+
+## Going Further
+
+- Apply the delegation matrix to a full day of actual work. Track which tasks
+  you delegate and the rework rate. After a week, review the pattern.
+- Try delegating Task A (the rate limiter) with a comprehensive spec that
+  covers every edge case. Measure: is the spec harder to write than the code?
+  This is the threshold where delegation stops saving time.
+- Identify a task at work that sits in the ambiguous middle of the matrix.
+  Try it both ways (self-implement and agent-delegated) and measure the
+  difference in total time including verification.

--- a/cotudes/STE-004-context-window-economics/README.md
+++ b/cotudes/STE-004-context-window-economics/README.md
@@ -1,0 +1,239 @@
+# STE-004: Context Window Economics
+
+> **Axiom**: The agent's context window is not a database -- every token competes for attention.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff Software Engineer |
+| **Number** | STE-004 |
+| **Primary Competency** | Context Engineering |
+| **Secondary Competency** | Specification Writing |
+| **Trap Severity** | 3 (Practiced) |
+| **Prerequisites** | STE-001 (The CLAUDE.md), STE-002 (Spec-Driven Development) |
+| **Duration** | 90-120 minutes |
+| **Stack** | Go |
+
+## Overview
+
+You will make a targeted change to one module in a multi-package Go service. The
+codebase has 50+ files. How much of it you feed to the agent -- and which parts --
+directly determines output quality. You will measure the difference between
+flooding the context and curating it.
+
+## Why Your Coding Agent Cares
+
+When you work in a large codebase, you mentally filter. You know which files
+matter for a given change and which are irrelevant. You do not hold the entire
+codebase in your head -- you hold a working set of 3-8 files plus a rough map
+of the rest.
+
+Agents have a context window, not a working memory. Everything you put in the
+window receives attention -- literally. The transformer architecture distributes
+attention across all tokens. When you include 50 files, the agent attends to
+patterns, names, and structures in all of them. The signal from the 3 files that
+actually matter is diluted by the noise from the 47 that do not.
+
+This manifests as specific, observable degradation. The agent starts borrowing
+patterns from unrelated files: it uses the error handling from the auth package
+in the billing module, it names variables after conventions in the CLI layer
+when writing API code, it imports packages it saw in the context but does not
+need. The output compiles, but it is a chimera -- pieces of the entire codebase
+stitched together rather than a focused implementation in the target module.
+
+The fix is curation, not restriction. The agent needs context -- but the right
+context. For a change in the billing module, it needs: the billing module itself,
+the interfaces it depends on (not the implementations), and any shared types or
+contracts. This is typically 5-8 files, totaling a few hundred lines. The rest
+is noise.
+
+The economics are real. Context window tokens cost money and latency. More
+importantly, they cost quality. There is a measurable inflection point where
+adding more context starts reducing output quality rather than improving it.
+Finding that point is a skill.
+
+## The Setup
+
+The `starter/` directory contains **taskflow**, now grown to a realistic size:
+50+ files across multiple packages.
+
+```
+internal/
+  api/        -- HTTP handlers (8 files)
+  store/      -- Database layer (6 files)
+  notify/     -- Notification worker (4 files)
+  auth/       -- Authentication middleware (5 files)
+  billing/    -- Billing and usage tracking (6 files)
+  metrics/    -- Metrics collection (3 files)
+  queue/      -- Job queue (4 files)
+  config/     -- Configuration loading (3 files)
+  models/     -- Shared types (4 files)
+  middleware/ -- HTTP middleware chain (5 files)
+```
+
+Your assignment: Add **usage-based billing** to the billing module. When a user
+makes an API request, the billing module should track the request, categorize it
+by endpoint type, and update the user's usage counter. This change primarily
+touches `internal/billing/` and `internal/models/usage.go`, with a minor
+integration point in `internal/middleware/`.
+
+Acceptance criteria:
+- `internal/billing/tracker.go` -- new file implementing usage tracking
+- `internal/billing/tracker_test.go` -- table-driven tests
+- `internal/models/usage.go` -- new usage event type
+- `internal/middleware/billing.go` -- middleware that calls the tracker
+- Existing tests pass; new tests cover the billing tracker
+- The implementation follows the billing package's existing patterns, not
+  patterns from other packages
+
+```bash
+cd starter/
+go build ./...
+go test -race -count=1 ./...
+wc -l internal/**/*.go | tail -1  # see total codebase size
+```
+
+## Part 1: The Natural Approach
+
+You want the agent to understand the full codebase so it can make informed
+decisions. Provide comprehensive context.
+
+Give the agent the complete codebase. You can do this by opening a session in
+the project root and telling the agent to read all Go files, or by pasting the
+contents of every package. The goal is to ensure the agent "knows everything"
+before it starts.
+
+Then ask it to implement usage-based billing as described in the acceptance
+criteria. Let the agent work.
+
+Review the output carefully. For each file the agent produces, note:
+
+1. Which package's patterns it follows (billing, or something else?)
+2. What imports it includes (are they all necessary?)
+3. What naming conventions it uses (do they match the billing package?)
+4. Whether it introduces any types, patterns, or abstractions borrowed from
+   unrelated packages
+
+Record in your interaction log:
+1. Total lines of context provided to the agent
+2. Files produced and their quality
+3. Patterns borrowed from unrelated packages
+4. Time spent reviewing and correcting
+
+### Checkpoint
+
+- [ ] Does `tracker.go` follow the patterns in `internal/billing/`, or does it
+      borrow patterns from `internal/auth/` or `internal/queue/`?
+- [ ] Does the middleware follow `internal/middleware/` conventions, or does it
+      introduce patterns from other packages?
+- [ ] Are there unnecessary imports from packages the billing module should not
+      depend on?
+- [ ] Does the agent's variable naming match the billing package or the
+      codebase at large?
+- [ ] Did the agent introduce any abstractions (interfaces, factories, wrappers)
+      that exist elsewhere in the codebase but are not needed here?
+- [ ] How confident are you that the output fits the billing module specifically?
+
+## Part 2: The Effective Approach
+
+Reset the codebase. This time, curate the context deliberately.
+
+Identify the minimal context the agent needs:
+
+**Essential (include)**:
+- `internal/billing/` -- all existing files (the agent needs the package's
+  patterns, types, and conventions)
+- `internal/models/` -- shared types the billing module depends on
+- `internal/middleware/billing.go` (if it exists) or one existing middleware
+  file as a pattern reference
+- The interface that `billing` exposes to other packages (not the consumers'
+  implementations)
+
+**Useful (include as summaries)**:
+- The API route registration (so the agent understands where middleware hooks in)
+- The billing package's test file (so the agent matches test patterns)
+
+**Noise (exclude)**:
+- `internal/auth/` -- different domain, different patterns
+- `internal/queue/` -- irrelevant to this change
+- `internal/notify/` -- irrelevant to this change
+- `internal/metrics/` -- the billing module has its own metrics approach
+- `internal/config/` -- unless billing reads config directly
+
+Provide only the essential and useful context. For the useful items, consider
+providing just the interface signatures rather than full implementations.
+
+Write a brief prompt that frames the task within the billing package:
+"Implement usage tracking in the billing package. Follow the existing patterns
+in this package. Here are the files..." Then include only the curated context.
+
+Review the output against the same criteria as Part 1.
+
+### Checkpoint
+
+- [ ] Does the output match billing package patterns more closely than Part 1?
+- [ ] Are there fewer unnecessary imports?
+- [ ] Is the naming more consistent with the target package?
+- [ ] Did the agent avoid introducing patterns from packages it never saw?
+- [ ] Compare the total review/correction time to Part 1.
+- [ ] How many lines of context did you provide vs. Part 1? What was the ratio
+      of quality improvement to context reduction?
+
+## The Principle
+
+The context window is an economic system. Every token has an opportunity cost.
+Including a file means every other file in the context receives proportionally
+less attention. This is not a metaphor -- it is how transformer attention works.
+
+Staff engineers accumulate context naturally: years in a codebase build a mental
+map that lets you filter without thinking. The instinct to give the agent "all
+the context" is an attempt to replicate your mental map in the agent. But your
+mental map has structure -- foreground and background, relevant and irrelevant,
+active and dormant. The context window is flat. Everything in it is equally
+available to the attention mechanism.
+
+The practical rule: for a change in module X, the agent needs:
+1. **Module X itself** -- full files, all conventions and patterns
+2. **Interfaces X depends on** -- signatures only, not implementations
+3. **Shared types** -- data structures that cross module boundaries
+4. **One example** -- of any new pattern you want the agent to follow
+
+This is typically 10-20% of a medium codebase. The other 80% is noise that
+actively degrades output.
+
+The skill is curation. You already do this for junior engineers: "You only need
+to look at these files for this change." Do the same for the agent. The agent
+is better than a junior at following patterns -- but only the patterns you show
+it.
+
+> **The agent's context window is not a database -- every token competes for attention.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Attention audit**: In Part 1, which unrelated package most influenced the
+   agent's output? Can you trace specific patterns in the output to specific
+   files in the context?
+2. **Curation cost**: How long did it take to curate context in Part 2? Is this
+   cost justified by the quality improvement?
+3. **The 80/20 point**: Estimate the percentage of the codebase that was
+   relevant to this change. How close was your curated set to this ideal?
+4. **Signal density**: Compare the ratio of useful-context-tokens to
+   total-context-tokens in Part 1 vs. Part 2. What was the signal density in
+   each case?
+5. **Transfer**: For your actual codebase at work, what is the typical module
+   boundary? How would you curate context for a change within that boundary?
+
+## Going Further
+
+- Run the same task three times with increasing context: (a) just the billing
+  package, (b) billing + interfaces, (c) the full codebase. Score output quality
+  on a 1-5 scale for each. Plot the curve. Where is the inflection point?
+- Experiment with context summaries: instead of including full files from
+  related packages, write 2-3 sentence summaries. Compare output quality to
+  full-file inclusion. Is the summary sufficient?
+- Try a change that genuinely requires broad context (a cross-cutting refactor).
+  Does the curated approach still work, or does the nature of the task demand
+  a wider window? What is the threshold?

--- a/cotudes/STE-005-the-parallel-sprint/README.md
+++ b/cotudes/STE-005-the-parallel-sprint/README.md
@@ -1,0 +1,267 @@
+# STE-005: The Parallel Sprint
+
+> **Axiom**: Parallelize independent work; serialize shared interfaces.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff Software Engineer |
+| **Number** | STE-005 |
+| **Primary Competency** | Parallel Orchestration |
+| **Secondary Competency** | Specification Writing |
+| **Trap Severity** | 3 (Practiced) |
+| **Prerequisites** | STE-002 (Spec-Driven Development), STE-003 (The Delegation Matrix) |
+| **Duration** | 150-180 minutes |
+| **Stack** | Go |
+
+## Overview
+
+You will implement a feature across five components by launching multiple agent
+sessions in parallel. The feature has both independent and interdependent parts.
+How you partition the work -- and when you synchronize -- determines whether the
+pieces merge cleanly or produce integration failures.
+
+## Why Your Coding Agent Cares
+
+Parallel agent sessions are the staff engineer's throughput multiplier. Instead
+of implementing five components sequentially in one session, you launch five
+sessions and get results in the time it takes to do one. The math is compelling.
+The reality is more complicated.
+
+Each agent session is isolated. Session A does not know what Session B decided.
+If both sessions touch a shared interface -- say, the event payload structure
+that component A emits and component B consumes -- they will each invent their
+own version. Session A decides events have a `timestamp` field (Unix epoch).
+Session B decides they have a `created_at` field (RFC 3339). Both are reasonable.
+Both are different. You discover this when you merge and the consumer cannot
+parse the producer's output.
+
+This is not a bug in the agent. It is a fundamental property of independent
+processes without shared state. Distributed systems engineers know this
+intuitively: you cannot have consistency without coordination. The same
+principle applies to parallel agent sessions. Independent sessions that touch
+shared interfaces will diverge unless you provide a coordination mechanism.
+
+The coordination mechanism is the contract. Before launching parallel sessions,
+define every shared interface: event schemas, API contracts, shared types,
+database schemas. Each session receives the contract as context. Each session
+implements against the contract, not against its own interpretation. The sessions
+remain independent in execution but aligned on interfaces.
+
+The partition strategy matters equally. Some tasks are genuinely independent:
+adding a new endpoint and writing documentation for an existing one share no
+interface. Others are deeply coupled: the API handler and the database migration
+for the same feature share field names, types, and constraints. Independent
+tasks parallelize safely. Coupled tasks need sequential execution or a shared
+contract.
+
+## The Setup
+
+The `starter/` directory contains **taskflow** with a new feature request:
+**Audit Logging**. Every significant action in the system should produce an
+audit log entry that is stored, queryable, and exportable.
+
+The feature has five components:
+
+**Component 1 -- Audit Event Model**: Define the audit event type in
+`internal/models/audit.go`. Fields: event ID, actor (user ID), action (string
+enum), resource type, resource ID, timestamp, metadata (JSON blob).
+
+**Component 2 -- Audit Store**: Implement `internal/store/audit.go` with
+database operations: insert event, query events by filter (actor, action,
+resource, time range), count events.
+
+**Component 3 -- Audit Middleware**: Implement `internal/middleware/audit.go`
+that intercepts API requests and emits audit events for mutating operations
+(POST, PUT, DELETE).
+
+**Component 4 -- Audit API**: Implement `internal/api/audit.go` with endpoints:
+`GET /audit` (list with filters), `GET /audit/{id}` (single event),
+`GET /audit/export` (CSV export).
+
+**Component 5 -- Audit Worker**: Implement `internal/audit/worker.go` that
+processes audit events asynchronously: enrichment (resolve user ID to name),
+retention policy enforcement (delete events older than 90 days), and aggregation
+(daily summary counts).
+
+Dependencies between components:
+- Components 2, 3, 4, and 5 all depend on the event model (Component 1)
+- Component 3 (middleware) produces events that Component 2 (store) persists
+- Component 4 (API) reads from Component 2 (store)
+- Component 5 (worker) reads from and writes to Component 2 (store)
+- Components 3, 4, and 5 are otherwise independent of each other
+
+```bash
+cd starter/
+go build ./...
+go test -race -count=1 ./...
+```
+
+## Part 1: The Natural Approach
+
+Five components. Five agent sessions. Launch them all.
+
+Open five separate agent sessions (or use five separate prompts in parallel-capable
+tooling). Assign one component to each session. Give each session the full task
+description for its component and access to the existing codebase.
+
+Do not write a shared contract. Do not define the audit event type upfront. Let
+each session determine what it needs from the shared model based on its own
+component's requirements.
+
+When all five sessions complete, merge the outputs into the codebase. Attempt
+to build and test.
+
+Record in your interaction log:
+1. How you described each component to its session
+2. The exact field names and types each session used for the audit event
+3. Build errors after merging
+4. Test failures after merging
+5. Time spent resolving conflicts and integration issues
+
+### Checkpoint
+
+- [ ] Did the project compile after merging all five components?
+- [ ] Did all sessions agree on the audit event field names?
+- [ ] Did all sessions agree on the audit event field types?
+- [ ] Did the middleware produce events the store could persist?
+- [ ] Did the API query the store using the schema the store created?
+- [ ] Did the worker parse events in the format the middleware emits?
+- [ ] How many integration issues did you find? How long did they take to fix?
+- [ ] Could you have predicted which components would conflict?
+
+## Part 2: The Effective Approach
+
+Reset the codebase. This time, plan the parallelization.
+
+**Step 1: Define the contract (sequential, you do this first)**
+
+Before launching any agent session, define the shared interfaces. Create
+`specs/audit-contract.md`:
+
+```markdown
+## Audit Event Model
+
+| Field        | Go Type    | JSON Key       | DB Column      |
+|--------------|-----------|----------------|----------------|
+| ID           | string    | "id"           | id             |
+| ActorID      | string    | "actor_id"     | actor_id       |
+| Action       | string    | "action"       | action         |
+| ResourceType | string    | "resource_type"| resource_type  |
+| ResourceID   | string    | "resource_id"  | resource_id    |
+| Timestamp    | time.Time | "timestamp"    | timestamp      |
+| Metadata     | json.RawMessage | "metadata" | metadata    |
+
+## Action Enum Values
+"create", "update", "delete", "export"
+
+## Store Interface
+[Define the exact function signatures the store must implement]
+
+## Query Filter
+[Define the filter struct with exact field names]
+```
+
+Fill in every detail. Every field name, every type, every enum value. This is
+the coordination mechanism.
+
+**Step 2: Implement the model (sequential, one session)**
+
+Launch one agent session to implement Component 1 (the audit event model)
+against the contract. Review and commit. This is the foundation -- it must
+be correct before anything builds on it.
+
+**Step 3: Implement independent components (parallel, three sessions)**
+
+Now launch three sessions in parallel for Components 3, 4, and 5 (middleware,
+API, worker). Each session receives:
+- The contract document
+- The committed audit event model (Component 1)
+- The store interface from the contract (not the implementation)
+- The existing codebase files relevant to its package
+
+These three components are independent of each other. They only share the
+event model and store interface, both of which are defined.
+
+**Step 4: Implement the store (sequential or parallel)**
+
+Component 2 (the store) can run in parallel with Step 3 if the store interface
+is fully defined in the contract. If you are confident in the interface, launch
+it with the parallel batch. If not, run it sequentially after the model is
+committed.
+
+Merge all outputs. Build and test.
+
+### Checkpoint
+
+- [ ] Did the project compile after merging?
+- [ ] Were there any field name or type mismatches?
+- [ ] Did the contract cover all shared interfaces?
+- [ ] How many integration issues vs. Part 1?
+- [ ] How much time did the contract take to write?
+- [ ] What was the total wall-clock time (contract + parallel execution +
+      merge) vs. Part 1 (parallel execution + conflict resolution)?
+- [ ] Did any session deviate from the contract? If so, was the contract
+      ambiguous or did the agent ignore it?
+
+## The Principle
+
+Parallel execution is a concurrency problem, and concurrency problems have a
+known solution: shared state must be synchronized. In agent orchestration,
+shared state is shared interfaces -- types, schemas, contracts, and conventions
+that multiple sessions depend on.
+
+The naive approach treats agent sessions like independent microservices that
+will "figure it out" at integration time. This works for truly independent
+tasks (writing tests for module A while adding a feature to module B). It
+fails for coupled tasks, and the failure mode is expensive: you discover
+mismatches only after all sessions complete, the merge is manual, and fixing
+one component's assumptions often cascades into changes in others.
+
+The effective approach applies the same dependency analysis you use for
+distributed systems. Draw the dependency graph. Identify shared interfaces.
+Define those interfaces first (this is sequential and cannot be parallelized).
+Then parallelize the implementations against the defined interfaces.
+
+The throughput gain is real but not 5x. If a feature has five components,
+two sequential dependency-definition steps, and three parallelizable
+implementations, your wall-clock time is roughly: contract time + max(three
+implementations) + merge time. This is significantly faster than sequential,
+and -- critically -- the merge step is trivial because the interfaces were
+defined upfront.
+
+The skill is dependency analysis. Before launching parallel sessions, ask:
+"If these two sessions make different assumptions about X, will the merge
+break?" If yes, X must be defined before both sessions launch.
+
+> **Parallelize independent work; serialize shared interfaces.**
+
+## Reflection
+
+Record in your interaction log:
+
+1. **Dependency graph**: Draw the dependency graph for the five components.
+   Which edges did you miss in Part 1? Which edges did the contract cover
+   in Part 2?
+2. **Contract completeness**: What did the contract miss? Did any integration
+   issue in Part 2 trace back to a gap in the contract?
+3. **Partition quality**: Were the three parallel components truly independent?
+   Did any pair share an implicit dependency the contract did not capture?
+4. **Time accounting**: Break down wall-clock time: contract writing, parallel
+   execution (wall-clock, not sum), merge/fix. Compare to Part 1's breakdown:
+   parallel execution, merge/fix.
+5. **Scaling intuition**: If this feature had 10 components instead of 5, how
+   would the contract approach scale? What about the uncoordinated approach?
+
+## Going Further
+
+- Take a real feature from your backlog. Decompose it into components. Draw
+  the dependency graph. Identify which components can parallelize and which
+  must serialize. Execute the plan with parallel agent sessions.
+- Experiment with contract granularity: try a minimal contract (just type
+  names and field names) vs. a detailed contract (full function signatures,
+  error codes, validation rules). Where is the sweet spot?
+- Try having one "architect" agent session generate the contract from a feature
+  description, then use that contract to coordinate implementation sessions.
+  Does the agent-generated contract cover the right interfaces?

--- a/cotudes/STE-015-system-feature/README.md
+++ b/cotudes/STE-015-system-feature/README.md
@@ -1,0 +1,319 @@
+# STE-015: System Feature
+
+> **Axiom**: Your workflow is a distributed system -- design it like one.
+
+## Metadata
+
+| Field | Value |
+|-------|-------|
+| **Path** | Staff Software Engineer |
+| **Number** | STE-015 |
+| **Primary Competency** | All |
+| **Trap Severity** | N/A (Capstone) |
+| **Prerequisites** | STE-001 through STE-014 |
+| **Duration** | 16-24 hours (3-4 working days) |
+| **Stack** | Go |
+
+## Overview
+
+You will design and implement a webhook delivery system across four Go services
+in the taskflow platform. The feature spans service boundaries, requires shared
+contracts, involves both delegatable and non-delegatable components, and must be
+delivered across multiple agent sessions over multiple days. You produce two
+artifacts: working code and a documented workflow playbook that another staff
+engineer on your team could follow to deliver a comparably scoped feature using
+agents.
+
+This capstone does not teach a new competency. It tests whether the competencies
+from STE-001 through STE-014 have become reflexive. There is no Part 1 / Part 2
+contrast. You execute once, applying everything you have learned, and evaluate the
+result against the rubric.
+
+## The Scenario
+
+Taskflow has grown. The monolithic service from earlier etudes has been decomposed
+into four services that communicate via an internal event bus:
+
+```
+services/
+  gateway/         -- API gateway, route registration, auth middleware
+  projects/        -- Project and task domain logic, primary data store
+  events/          -- Event ingestion, routing, fan-out
+  workers/         -- Async job processing (notifications, cleanup, aggregation)
+```
+
+Each service has its own `internal/` packages, its own test suite, its own
+conventions (some shared, some divergent -- the team grew and conventions
+drifted). A shared `pkg/` directory contains common types and interfaces.
+
+**The feature**: Webhook Delivery.
+
+Users can register webhook URLs for their projects. When significant events occur
+(task created, task completed, project archived, team membership changed), the
+system delivers an HTTP POST to the registered URL with a signed JSON payload.
+Delivery includes retry logic with exponential backoff, a dead-letter queue for
+persistent failures, and an admin API for inspecting delivery status and manually
+retrigering failed deliveries.
+
+The feature touches all four services:
+
+1. **Gateway** -- New endpoints: webhook registration CRUD
+   (`POST/GET/PUT/DELETE /projects/{id}/webhooks`), delivery status query
+   (`GET /projects/{id}/webhooks/{wid}/deliveries`), manual retry trigger
+   (`POST /deliveries/{did}/retry`).
+
+2. **Projects** -- New domain model: `Webhook` (URL, secret, event filters,
+   active flag). Persistence layer for webhook configurations. Validation logic
+   (URL reachability check, secret generation, event filter validation against
+   known event types).
+
+3. **Events** -- New routing logic: when an event arrives, check for matching
+   webhook subscriptions, fan out delivery jobs. New event types for webhook
+   lifecycle events (webhook.registered, webhook.delivery.succeeded,
+   webhook.delivery.failed).
+
+4. **Workers** -- New job type: webhook delivery. HTTP POST with HMAC-SHA256
+   signature, configurable timeout, exponential backoff (initial 1s, max 1h,
+   jitter), circuit breaker per destination URL, dead-letter after 8 attempts.
+   Delivery logging with full request/response capture for debugging.
+
+Cross-cutting concerns:
+- The HMAC signing algorithm must be identical in the workers service (which
+  signs) and documented in a way that external consumers can verify.
+- Event payloads must be serialized identically regardless of which service
+  originates the event.
+- Retry state must be queryable from the gateway but is owned by the workers
+  service. This requires a defined interface between services.
+- Webhook secrets must be stored encrypted at rest in the projects service
+  and transmitted to the workers service only at delivery time, never exposed
+  in any API response.
+
+### Why This Feature
+
+This is not a contrived exercise. Webhook delivery is a common system feature
+that exposes exactly the challenges of multi-service development with agents:
+shared contracts (payload schemas, signing protocols), mixed delegation suitability
+(CRUD endpoints vs. retry algorithms), parallelizable components with shared
+interfaces, context management across service boundaries, and subtle correctness
+requirements that agents handle poorly without human oversight (cryptographic
+signing, backoff jitter, circuit breaker state machines).
+
+## Deliverables
+
+### A. Working Code
+
+All four services extended with the webhook feature. Specifically:
+
+1. **Gateway endpoints** -- All six endpoints listed above, following the
+   gateway service's existing conventions for routing, middleware, error
+   responses, and request validation.
+
+2. **Projects domain model** -- `Webhook` type, store layer, validation.
+   Migration script for the webhooks table. Tests.
+
+3. **Events routing** -- Fan-out logic, webhook lifecycle events. Tests
+   covering event matching with filters.
+
+4. **Workers delivery job** -- HTTP delivery with signing, retry with backoff
+   and jitter, circuit breaker, dead-letter queue, delivery logging. Tests
+   covering the retry state machine, signature correctness, and circuit breaker
+   transitions.
+
+5. **Integration test** -- At least one end-to-end test that registers a webhook,
+   triggers an event, and asserts that the delivery arrives with a valid
+   signature and correct payload.
+
+6. **Shared contract** -- `pkg/webhook/` with types and interfaces used across
+   services. Event payload schema. Delivery status enum. Signing utility (used
+   by workers, importable by external consumers for verification).
+
+All existing tests pass. New tests cover the new code. `go build ./...` succeeds
+for every service. `go test -race -count=1 ./...` passes for every service.
+
+### B. Workflow Playbook
+
+A document (`PLAYBOOK.md` in the repo root) that records the workflow you used to
+deliver this feature. Not a journal or narrative -- a playbook another engineer
+could follow. It must contain:
+
+1. **CLAUDE.md decisions** -- What you put in each service's CLAUDE.md and why.
+   What you put in the root CLAUDE.md vs. service-level ones. What you learned
+   about context layering across a multi-service repo.
+
+2. **Specification artifacts** -- The specs and contracts you wrote before
+   implementation. The order you wrote them. Which specs were worth the time
+   and which were over-specified.
+
+3. **Delegation log** -- Which components you delegated to agents and which you
+   implemented yourself. Your reasoning for each decision, mapped to the
+   delegation matrix from STE-003.
+
+4. **Parallelization plan** -- Which agent sessions ran in parallel, which ran
+   sequentially, and why. The dependency graph you used to make this decision.
+   Where parallelization saved time and where it created integration overhead.
+
+5. **Context budgets** -- For each major agent session, what context you
+   provided. What you excluded. Approximate token counts if you tracked them.
+   Any evidence of context pollution (agent borrowing patterns from the wrong
+   service).
+
+6. **Review protocol** -- How you reviewed agent output. What you checked first.
+   What categories of errors you found. Whether you used automated verification
+   (tests, linting, type checking) vs. manual review, and for which components.
+
+7. **Recovery incidents** -- Any sessions that went sideways. How you detected
+   the problem, what you did (restart, narrow scope, take over manually), and
+   what you would do differently.
+
+8. **Session map** -- A timeline of sessions: how many, what each one
+   accomplished, how context was transferred between sessions, and where
+   session boundaries caused friction.
+
+The playbook is evaluated on whether a peer could follow it, not on polish.
+
+## Constraints
+
+These constraints exist to ensure every prior competency is exercised. They are
+not artificial restrictions -- they reflect the realities of multi-service
+development at scale.
+
+1. **Multi-session mandate**. You may not complete this in a single agent session.
+   The feature must span at least 6 distinct sessions (simulating work across
+   multiple days). Each session must start cold -- no relying on an open session's
+   accumulated context. This forces STE-001 (CLAUDE.md) and STE-010 (Session
+   Continuity).
+
+2. **Spec-first**. No implementation may begin on any component until you have
+   written a specification for the shared contracts (event payload schema, signing
+   protocol, delivery status types, store interfaces). The spec is a deliverable
+   and will be evaluated. This forces STE-002 (Spec-Driven Development).
+
+3. **Delegation decision log**. For every component, you must record before
+   starting whether you will delegate it to an agent or implement it yourself,
+   with a one-sentence justification. You may change your mind during execution
+   but must record why. This forces STE-003 (The Delegation Matrix).
+
+4. **Context budget per session**. For each agent session, document the files
+   and context you provided. At least two sessions must use deliberately curated
+   context (not "give the agent everything"). This forces STE-004 (Context
+   Window Economics).
+
+5. **Parallel execution**. At least two agent sessions must run in parallel on
+   independent components, coordinated by a shared contract. This forces STE-005
+   (The Parallel Sprint).
+
+6. **Architecture constraint**. The `pkg/webhook/` shared package must define
+   interfaces, not implementations. Services depend on the interfaces. This
+   forces STE-006 (Agent-Friendly Architecture) -- the agent must navigate the
+   abstraction boundary correctly.
+
+7. **Human review required**. The HMAC signing implementation and the retry
+   state machine must be reviewed line-by-line by you, with annotations in the
+   playbook on what you checked and why. You may not rely solely on tests for
+   these components. This forces STE-007 (The Review Protocol) and STE-013
+   (The Performance Review).
+
+8. **At least one recovery**. If every session succeeds perfectly on the first
+   attempt, you are either extraordinarily well-prepared or not pushing hard
+   enough. The playbook must include at least one recovery incident -- a session
+   that required course correction. If none occur naturally, deliberately attempt
+   one component with insufficient context and document the recovery. This forces
+   STE-008 (Recovery and Restart).
+
+9. **CI verification loop**. Every component must pass `go build` and `go test`
+   before the next component begins. No "I'll fix it at integration." This
+   forces STE-009 (The Feedback Machine).
+
+10. **Team-shareable output**. The playbook must be written as if you are
+    establishing a pattern for your team. It should include reusable templates
+    (CLAUDE.md template, spec template, delegation checklist). This forces
+    STE-014 (Team Patterns).
+
+## Evaluation Criteria
+
+### Code Quality (40%)
+
+| Criterion | Exceeds | Meets | Below |
+|-----------|---------|-------|-------|
+| **Compiles and passes tests** | All services pass with race detector, >80% coverage on new code | All services pass, reasonable coverage | Build failures or test gaps |
+| **Convention adherence** | New code is indistinguishable from existing code in each service | Minor convention drift, easily correctable | Obvious style mismatches across services |
+| **Contract fidelity** | Implementation matches spec exactly across all service boundaries | Minor deviations, no integration failures | Spec and implementation diverge; integration issues |
+| **Correctness of critical paths** | HMAC signing is correct and tested; retry logic handles all edge cases; circuit breaker transitions are sound | Signing works; retry has basic coverage; circuit breaker is present | Signing has subtle bugs; retry lacks jitter or has off-by-one; no circuit breaker |
+| **Integration** | End-to-end test passes; services communicate correctly | Most paths work; minor integration fixes needed | Services do not integrate without significant rework |
+
+### Workflow Quality (40%)
+
+| Criterion | Exceeds | Meets | Below |
+|-----------|---------|-------|-------|
+| **CLAUDE.md effectiveness** | Service-level CLAUDE.md files show evidence of iteration; entries trace to specific correction incidents | CLAUDE.md files exist and cover key conventions | Generic or copied CLAUDE.md files |
+| **Specification value** | Specs are minimal but sufficient; no over-specification; integration issues traceable to spec gaps, not spec absence | Specs exist and were used; some over- or under-specification | Specs written after implementation or not used |
+| **Delegation accuracy** | Delegation decisions match the verification-cost heuristic; human-implemented components are the correct ones | Mostly correct delegation; one or two suboptimal choices | Delegation based on interest/boredom rather than verifiability |
+| **Parallelization efficiency** | Clear dependency graph; parallel sessions merge without integration issues; wall-clock savings documented | Some parallelization; minor merge issues | No parallelization, or parallel sessions conflict |
+| **Context curation** | Evidence of deliberate context selection; no context pollution in output; budget documented per session | Context considered; some curation | Agent given entire repo every session |
+| **Review rigor** | Critical components reviewed with specific annotations; error categories documented; automated + manual verification combined | Review performed; some documentation | Cursory review or no documentation |
+
+### Playbook Quality (20%)
+
+| Criterion | Exceeds | Meets | Below |
+|-----------|---------|-------|-------|
+| **Reproducibility** | A peer could follow the playbook to deliver a similar feature; templates are reusable | Playbook describes the workflow; a peer could learn from it | Journal entries, not a playbook |
+| **Honesty** | Recovery incidents documented with genuine reflection; mistakes are visible | Some reflection on what worked and didn't | Only successes documented |
+| **Completeness** | All eight playbook sections present and substantive | Most sections present | Major sections missing |
+
+### Overall Scoring
+
+- **Exceeds across all categories**: You have internalized the STE path competencies. The workflow is yours, not a checklist.
+- **Meets across all categories**: You can apply the competencies when prompted. Practice will make them automatic.
+- **Mixed**: Review the specific categories where you scored Below. Revisit the corresponding etude.
+- **Below across multiple categories**: Revisit STE-008 through STE-014 before reattempting.
+
+## Reflection
+
+These questions look backward across the entire STE path. Take them seriously.
+Write full answers, not bullet points.
+
+1. **The CLAUDE.md audit**. Open the CLAUDE.md files you created for this
+   capstone. Compare them to the CLAUDE.md you wrote in STE-001. What changed
+   in how you think about persistent context? What would you tell the version
+   of yourself that started this path?
+
+2. **The spec ROI**. You wrote specs before implementation. Estimate the time
+   you spent on specs vs. the integration time they saved. Is spec-driven
+   development now a reflex or still a discipline you impose on yourself? When
+   would you skip it?
+
+3. **The delegation instinct**. Look at your delegation log. Did your gut
+   instinct for what to delegate match the verification-cost heuristic, or did
+   you still have to override your instincts? Has the heuristic become
+   intuitive?
+
+4. **The parallelization judgment**. You ran parallel sessions. How did your
+   dependency analysis compare to what you would have done in STE-005? Are you
+   better at identifying shared interfaces before they cause merge conflicts?
+
+5. **The context skill**. Across all sessions, where did context curation most
+   obviously improve output quality? Where did you still get it wrong? What is
+   your personal heuristic for "enough context" now?
+
+6. **The review evolution**. Compare how you reviewed agent output in this
+   capstone to how you reviewed it before the path. What do you check first?
+   What do you trust? What do you never trust?
+
+7. **The workflow as artifact**. You produced a playbook. Is this how you
+   actually work now, or is it aspirational? What parts of the playbook would
+   you actually share with your team on Monday?
+
+8. **The 19% question**. The METR study found experienced developers initially
+   took 19% longer with agents. After completing this path, are you faster with
+   agents than without? On which types of work? On which types are you still
+   faster alone? Be specific.
+
+9. **The axiom stack**. List the axioms from STE-001 through STE-014 that you
+   actually used during this capstone. Which ones have become part of your
+   thinking? Which ones did you forget and had to relearn? Which ones do you
+   disagree with?
+
+10. **The next engineer**. A new staff engineer joins your team next week. They
+    are skeptical of agents. They can write Go faster than they can review
+    agent-generated Go. What is the first thing you would have them do? What is
+    the one sentence you would tell them?


### PR DESCRIPTION
Write etudes STE-002 through STE-005 (Spec-Driven Development,
The Delegation Matrix, Context Window Economics, The Parallel Sprint),
PSA-002 through PSA-004 (The Specification as Contract, Modular
Boundaries, The Evolutionary Architecture), and DOE-002 through
DOE-005 (IaC with Agents, Pipeline as Agent Guardrail, The Dockerfile,
Security Scanning). Each follows the trap-then-correct pedagogy with
role-appropriate engineering tasks.

https://claude.ai/code/session_01LN7Syi9bqsgr6vaPZ4yYox